### PR TITLE
Calendar Light/Dark Mode Bug Fix

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -132,37 +132,6 @@ export default function FlowCalendar() {
       <TouchableWithoutFeedback onPress={dismissKeyboard}>
         <KeyboardAvoidingView style={{ flex: 1 }}>
           <SafeAreaView style={styles.container}>
-            <View
-              key={themeKey}
-              style={{ backgroundColor: theme.colors.background, padding: 4 }}
-            >
-              <Calendar
-                maxDate={today}
-                markedDates={{ ...storedDatesState }}
-                enableSwipeMonths={true}
-                onDayPress={(day: { dateString: string }) =>
-                  setDate(day.dateString)
-                }
-                theme={{
-                  calendarBackground: theme.colors.background,
-                  textSectionTitleColor: theme.colors.secondary,
-                  selectedDayBackgroundColor: theme.colors.primary,
-                  selectedDayTextColor: theme.colors.onPrimary,
-                  todayTextColor: theme.colors.primary,
-                  dayTextColor: theme.colors.onBackground,
-                  textDisabledColor: theme.colors.surfaceVariant,
-                  arrowColor: theme.colors.primary,
-                  monthTextColor: theme.colors.primary,
-                  textDayFontFamily: "monospace",
-                  textMonthFontFamily: "monospace",
-                  textDayHeaderFontFamily: "monospace",
-                  textDayFontSize: 16,
-                  textMonthFontSize: 16,
-                  textDayHeaderFontSize: 16,
-                }}
-              />
-              <Divider />
-            </View>
             <ScrollView
               contentContainerStyle={{
                 flexGrow: 1,
@@ -170,6 +139,37 @@ export default function FlowCalendar() {
               }}
               automaticallyAdjustKeyboardInsets={true}
             >
+              <View
+                key={themeKey}
+                style={{ backgroundColor: theme.colors.background, padding: 4 }}
+              >
+                <Calendar
+                  maxDate={today}
+                  markedDates={{ ...storedDatesState }}
+                  enableSwipeMonths={true}
+                  onDayPress={(day: { dateString: string }) =>
+                    setDate(day.dateString)
+                  }
+                  theme={{
+                    calendarBackground: theme.colors.background,
+                    textSectionTitleColor: theme.colors.secondary,
+                    selectedDayBackgroundColor: theme.colors.primary,
+                    selectedDayTextColor: theme.colors.onPrimary,
+                    todayTextColor: theme.colors.primary,
+                    dayTextColor: theme.colors.onBackground,
+                    textDisabledColor: theme.colors.surfaceVariant,
+                    arrowColor: theme.colors.primary,
+                    monthTextColor: theme.colors.primary,
+                    textDayFontFamily: "monospace",
+                    textMonthFontFamily: "monospace",
+                    textDayHeaderFontFamily: "monospace",
+                    textDayFontSize: 16,
+                    textMonthFontSize: 16,
+                    textDayHeaderFontSize: 16,
+                  }}
+                />
+                <Divider />
+              </View>
               <View>{date && <DayView />}</View>
             </ScrollView>
           </SafeAreaView>

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -124,6 +124,7 @@ export default function FlowCalendar() {
   const dismissKeyboard = () => {
     Keyboard.dismiss();
   };
+  
   const themeKey = theme.dark ? "dark-theme" : "light-theme";
 
   return (

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -134,6 +134,7 @@ export default function FlowCalendar() {
               style={{ backgroundColor: theme.colors.background, padding: 4 }}
             >
               <Calendar
+                key={`calendar-${theme.dark}`}
                 maxDate={today}
                 markedDates={{ ...storedDatesState }}
                 enableSwipeMonths={true}

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -124,6 +124,7 @@ export default function FlowCalendar() {
   const dismissKeyboard = () => {
     Keyboard.dismiss();
   };
+  const themeKey = theme.dark ? "dark-theme" : "light-theme";
 
   return (
     <SafeAreaProvider>
@@ -131,10 +132,10 @@ export default function FlowCalendar() {
         <KeyboardAvoidingView style={{ flex: 1 }}>
           <SafeAreaView style={styles.container}>
             <View
+              key={themeKey}
               style={{ backgroundColor: theme.colors.background, padding: 4 }}
             >
               <Calendar
-                key={`calendar-${theme.dark}`}
                 maxDate={today}
                 markedDates={{ ...storedDatesState }}
                 enableSwipeMonths={true}

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -124,7 +124,7 @@ export default function FlowCalendar() {
   const dismissKeyboard = () => {
     Keyboard.dismiss();
   };
-  
+
   const themeKey = theme.dark ? "dark-theme" : "light-theme";
 
   return (
@@ -170,36 +170,6 @@ export default function FlowCalendar() {
               }}
               automaticallyAdjustKeyboardInsets={true}
             >
-              <View
-                style={{ backgroundColor: theme.colors.background, padding: 4 }}
-              >
-                <Calendar
-                  maxDate={today}
-                  markedDates={{ ...storedDatesState }}
-                  enableSwipeMonths={true}
-                  onDayPress={(day: { dateString: string }) =>
-                    setDate(day.dateString)
-                  }
-                  theme={{
-                    calendarBackground: theme.colors.background,
-                    textSectionTitleColor: theme.colors.secondary,
-                    selectedDayBackgroundColor: theme.colors.primary,
-                    selectedDayTextColor: theme.colors.onPrimary,
-                    todayTextColor: theme.colors.primary,
-                    dayTextColor: theme.colors.onBackground,
-                    textDisabledColor: theme.colors.surfaceVariant,
-                    arrowColor: theme.colors.primary,
-                    monthTextColor: theme.colors.primary,
-                    textDayFontFamily: "monospace",
-                    textMonthFontFamily: "monospace",
-                    textDayHeaderFontFamily: "monospace",
-                    textDayFontSize: 16,
-                    textMonthFontSize: 16,
-                    textDayHeaderFontSize: 16,
-                  }}
-                />
-                <Divider />
-              </View>
               <View>{date && <DayView />}</View>
             </ScrollView>
           </SafeAreaView>


### PR DESCRIPTION
Fixed the issue with the calendar component not re-rendering when toggling between light and dark mode within the app by adding a key to the calendar that forces the component to reload when the theme changes. 