### PR TITLE
Fix database name discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,45 +21,45 @@
 
 <!-- ABOUT THE PROJECT -->
 
-
 ## About The Project
 
-Stay aware of your cycle without sacrificing your privacy. Ephira is a secure period-tracker that keeps your data encrypted locally on your device. 
+Stay aware of your cycle without sacrificing your privacy. Ephira is a secure period-tracker that keeps your data encrypted locally on your device.
 
-Track Your Health: Log menstrual flow, symptoms, moods, medications, birth control, and notes. 
+Track Your Health: Log menstrual flow, symptoms, moods, medications, birth control, and notes.
 
-Privacy First: Data is encrypted and never leaves your device. It can be locked behind biometrics (Face ID/Fingerprint) or a custom password, and can be deleted at any time. 
+Privacy First: Data is encrypted and never leaves your device. It can be locked behind biometrics (Face ID/Fingerprint) or a custom password, and can be deleted at any time.
 
 Open and Transparent: Ephira is open source under the MIT license, and you can review the code at any time on Github.
 
-
 <!-- DEVELOPMENT GOALS -->
+
 ## Development Goals
 
 - [ ] Android Play Store Deployment
-    - [ ] Review 
-    - [ ] User Testing 
+  - [ ] Review
+  - [ ] User Testing
 - [ ] Apple App Store Deployment
-    - [ ] Review 
-    - [ ] User Testing
+  - [ ] Review
+  - [ ] User Testing
 - [ ] App Features
-    - [ ] Cycle Prediction
-    - [ ] Data Export
-    - [ ] Animations
-    - [ ] Splash Screen
-    - [ ] Menstrual Cycle Insight
+  - [ ] Cycle Prediction
+  - [ ] Data Export
+  - [ ] Animations
+  - [ ] Splash Screen
+  - [ ] Menstrual Cycle Insight
 
 See the [open issues](https://github.com/adulbrich/ephira/issues) for a full list of proposed features (and known issues).
 
 <!-- LICENSE -->
+
 ## License
 
 [![License][license-shield]][license-url]
 
 See `LICENSE.txt` for more information.
 
-
 <!-- ACKNOWLEDGMENTS -->
+
 ## Acknowledgments
 
 ### Top contributors:
@@ -68,20 +68,23 @@ See `LICENSE.txt` for more information.
   <img src="https://contrib.rocks/image?repo=adulbrich/ephira" alt="contrib.rocks image" />
 </a>
 
-
 <!-- DESIGN GUIDE -->
+
 ## Design Guide
+
 ### Logo Colors
+
 - ![#f2e4bf](https://placehold.co/15x15/f2e4bf/f2e4bf.png) `#f2e4bf`
 - ![#9892a0](https://placehold.co/15x15/9892a0/9892a0.png) `#9892a0`
 - ![#65759a](https://placehold.co/15x15/65759a/65759a.png) `#65759a`
 - ![#312935](https://placehold.co/15x15/312935/312935.png) `#312935`
 
 ### Fonts
-[Minion Variable Concept](https://fonts.adobe.com/fonts/minion) 
 
+[Minion Variable Concept](https://fonts.adobe.com/fonts/minion)
 
 <!-- GETTING STARTED -->
+
 ## Getting Started
 
 ### Running the Project
@@ -102,7 +105,7 @@ In the output, you'll find options to open the app in a:
 - [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
 - [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
 
-This project uses [file-based routing](https://docs.expo.dev/router/introduction). 
+This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
 ### Learn more
 
@@ -113,10 +116,9 @@ To learn more about the libraries we use, look at the following resources:
 - [React Native Paper](https://reactnativepaper.com/)
 - [Drizzle (Expo SQLite)](https://orm.drizzle.team/docs/connect-expo-sqlite)
 
-
-
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
+
 [license-shield]: https://img.shields.io/github/license/adulbrich/ephira.svg?style=for-the-badge
 [license-url]: https://github.com/adulbrich/ephira/blob/master/LICENSE.txt
 [product-screenshot]: assets/images/feature-graphic.png
@@ -132,5 +134,3 @@ To learn more about the libraries we use, look at the following resources:
 [Android-url]: https://android.com
 [Apple.com]: https://img.shields.io/badge/IOS-%23000000.svg?style=for-the-badge&logo=apple&logoColor=white
 [Apple-url]: https://apple.com
-
-

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -23,8 +23,8 @@ import { AUTH_TYPES, SettingsKeys } from "@/constants/Settings";
 import { getDatabase, getDrizzleDatabase, getSetting } from "@/db/database";
 import DatabaseMigrationError from "@/components/DatabaseMigrationError";
 import PasswordAuthenticationView from "@/components/PasswordAuthenticationView";
+import { DATABASE_NAME } from "@/constants/Settings";
 
-const DB_NAME = "ephira.db";
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
@@ -142,7 +142,7 @@ export default function RootLayout() {
 
   return (
     <Suspense fallback={<ActivityIndicator size="large" />}>
-      <SQLiteProvider databaseName={DB_NAME} useSuspense>
+      <SQLiteProvider databaseName={DATABASE_NAME} useSuspense>
         <PaperProvider theme={theme}>
           <SafeAreaProvider>
             <SafeAreaView

--- a/constants/Settings.ts
+++ b/constants/Settings.ts
@@ -1,3 +1,5 @@
+export const DATABASE_NAME = "ephira.db";
+
 export const SettingsKeys = {
   authentication: "authentication",
   password: "password",

--- a/db/operations/setup.ts
+++ b/db/operations/setup.ts
@@ -1,8 +1,7 @@
 import * as SQLite from "expo-sqlite";
 import { drizzle } from "drizzle-orm/expo-sqlite";
 import * as schema from "@/db/schema";
-
-const DATABASE_NAME = "testing.db";
+import { DATABASE_NAME } from "@/constants/Settings";
 
 let expoDb: SQLite.SQLiteDatabase;
 


### PR DESCRIPTION
There was a discrepancy with the database name, it was "testing.db" in one file and "ephira.db" in another. I made a constant and the name is now imported so that it's the same everywhere. The README is only changed from `npm run format`. 