### PR TITLE
Change Entry Visibility

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -1,18 +1,30 @@
 import { ThemedView } from "@/components/ThemedView";
-import AuthenticationSettings from "@/components/AuthenticationSettings";
-import PrivacyPolicy from "@/components/ui/PrivacyPolicy";
-import DeleteData from "@/components/DeleteData";
-import { Text } from "react-native-paper";
+import AuthenticationSettings from "@/components/settings/AuthenticationSettings";
+import PrivacyPolicy from "@/components/settings/PrivacyPolicy";
+import DeleteData from "@/components/settings/DeleteData";
+import Customization from "@/components/settings/Customization";
+import { Text, Divider, useTheme } from "react-native-paper";
 import { ScrollView, SafeAreaView } from "react-native";
 
 export default function Settings() {
+  const theme = useTheme();
   return (
     <ThemedView style={{ height: "100%", padding: 10 }}>
       <SafeAreaView style={{ flex: 1 }}>
-        <Text variant="titleLarge" style={{ textAlign: "center" }}>
+        <Text
+          variant="titleLarge"
+          style={{
+            textAlign: "center",
+            fontSize: 30,
+            fontWeight: "bold",
+            color: theme.colors.onBackground,
+          }}
+        >
           Settings
         </Text>
+        <Divider style={{ marginTop: 10 }} />
         <ScrollView contentContainerStyle={{ paddingBottom: 60 }}>
+          <Customization />
           <AuthenticationSettings />
           <DeleteData />
           <PrivacyPolicy />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -93,9 +93,9 @@ export default function RootLayout() {
       const isDatabaseSetup = await getSetting(
         SettingsKeys.databaseInitialSetup,
       );
-      if (!isDatabaseSetup || isDatabaseSetup.value !== "true") {
+      if (!isDatabaseSetup || isDatabaseSetup.value !== "0000") {
         await setupEntryTypes();
-        await insertSetting(SettingsKeys.databaseInitialSetup, "true");
+        await insertSetting(SettingsKeys.databaseInitialSetup, "0000");
       }
 
       if (loaded && success) {

--- a/assets/src/calendar-storage.tsx
+++ b/assets/src/calendar-storage.tsx
@@ -15,6 +15,7 @@ import {
   TempSelectedTime,
   FlowDataState,
   CalendarFilters,
+  DatabaseChangeNotifier,
 } from "@/constants/Interfaces";
 
 const initialDay: DayData = {
@@ -128,3 +129,11 @@ export const useCalendarFilters = create<CalendarFilters>((set) => ({
   setSelectedFilters: (values: string[]) =>
     set(() => ({ selectedFilters: values })),
 }));
+
+export const useDatabaseChangeNotifier = create<DatabaseChangeNotifier>(
+  (set) => ({
+    databaseChange: "",
+    setDatabaseChange: (databaseChange: string) =>
+      set(() => ({ databaseChange: databaseChange })),
+  }),
+);

--- a/components/calendar/CalendarFilterDialog.tsx
+++ b/components/calendar/CalendarFilterDialog.tsx
@@ -13,9 +13,9 @@ import { useState, useEffect } from "react";
 import { SettingsKeys } from "@/constants/Settings";
 import {
   updateSetting,
-  getAllSymptoms,
-  getAllMoods,
-  getAllMedications,
+  getAllVisibleSymptoms,
+  getAllVisibleMoods,
+  getAllVisibleMedications,
 } from "@/db/database";
 import { useCalendarFilters } from "@/assets/src/calendar-storage";
 import { anySymptomOption } from "@/constants/Symptoms";
@@ -81,26 +81,25 @@ export default function CalendarFilterDialog({
     if (!visible) return;
 
     const fetchSymptoms = async () => {
-      const symptoms = await getAllSymptoms();
-      setSymptomOptions(
-        symptoms
-          .filter((symptom) => symptom.visible)
-          .map((symptom) => symptom.name),
-      );
+      const symptoms = await getAllVisibleSymptoms();
+      setSymptomOptions(symptoms.map((symptom) => symptom.name));
     };
 
     const fetchMoods = async () => {
-      const moods = await getAllMoods();
-      setMoodOptions(
-        moods.filter((mood) => mood.visible).map((mood) => mood.name),
-      );
+      const moods = await getAllVisibleMoods();
+      setMoodOptions(moods.map((mood) => mood.name));
     };
 
     const fetchMedications = async () => {
-      const medications = await getAllMedications();
+      const medications = await getAllVisibleMedications();
       setMedicationOptions(
         medications
-          .filter((medication) => medication.visible)
+          .filter((medication) => medication.type !== "birth control")
+          .map((medication) => medication.name),
+      );
+      setBirthControlOptions(
+        medications
+          .filter((medication) => medication.type === "birth control")
           .map((medication) => medication.name),
       );
     };
@@ -108,9 +107,6 @@ export default function CalendarFilterDialog({
     fetchSymptoms();
     fetchMoods();
     fetchMedications();
-
-    // change later!!!
-    setBirthControlOptions(bcData);
   }, [visible]);
 
   useEffect(() => {

--- a/components/calendar/CalendarFilterDialog.tsx
+++ b/components/calendar/CalendarFilterDialog.tsx
@@ -17,14 +17,14 @@ import {
   getAllVisibleMoods,
   getAllVisibleMedications,
 } from "@/db/database";
-import { useCalendarFilters } from "@/assets/src/calendar-storage";
+import {
+  useCalendarFilters,
+  useDatabaseChangeNotifier,
+} from "@/assets/src/calendar-storage";
 import { anySymptomOption } from "@/constants/Symptoms";
 import { anyMoodOption } from "@/constants/Moods";
 import { anyMedicationOption } from "@/constants/Medications";
-import {
-  birthControlOptions as bcData,
-  anyBirthControlOption,
-} from "@/constants/BirthControlTypes";
+import { anyBirthControlOption } from "@/constants/BirthControlTypes";
 const flowOption = "Flow";
 const notesOption = "Notes";
 
@@ -69,6 +69,7 @@ export default function CalendarFilterDialog({
   visible: boolean;
   setVisible: (visible: boolean) => void;
 }) {
+  const databaseChange = useDatabaseChangeNotifier().databaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
   const [tempSelectedFilters, setTempSelectedFilters] =
     useState<string[]>(selectedFilters);
@@ -78,8 +79,6 @@ export default function CalendarFilterDialog({
   const [birthControlOptions, setBirthControlOptions] = useState<string[]>([]);
 
   useEffect(() => {
-    if (!visible) return;
-
     const fetchSymptoms = async () => {
       const symptoms = await getAllVisibleSymptoms();
       setSymptomOptions(symptoms.map((symptom) => symptom.name));
@@ -107,7 +106,7 @@ export default function CalendarFilterDialog({
     fetchSymptoms();
     fetchMoods();
     fetchMedications();
-  }, [visible]);
+  }, [databaseChange]);
 
   useEffect(() => {
     setTempSelectedFilters(selectedFilters);

--- a/components/calendar/CalendarFilterDialog.tsx
+++ b/components/calendar/CalendarFilterDialog.tsx
@@ -11,16 +11,18 @@ import {
 import { ScrollView, View, Platform, StyleSheet } from "react-native";
 import { useState, useEffect } from "react";
 import { SettingsKeys } from "@/constants/Settings";
-import { updateSetting } from "@/db/database";
+import {
+  updateSetting,
+  getAllSymptoms,
+  getAllMoods,
+  getAllMedications,
+} from "@/db/database";
 import { useCalendarFilters } from "@/assets/src/calendar-storage";
-import { symptomOptions, anySymptomOption } from "@/constants/Symptoms";
-import { moodOptions, anyMoodOption } from "@/constants/Moods";
+import { anySymptomOption } from "@/constants/Symptoms";
+import { anyMoodOption } from "@/constants/Moods";
+import { anyMedicationOption } from "@/constants/Medications";
 import {
-  medicationOptions,
-  anyMedicationOption,
-} from "@/constants/Medications";
-import {
-  birthControlOptions,
+  birthControlOptions as bcData,
   anyBirthControlOption,
 } from "@/constants/BirthControlTypes";
 const flowOption = "Flow";
@@ -70,6 +72,46 @@ export default function CalendarFilterDialog({
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
   const [tempSelectedFilters, setTempSelectedFilters] =
     useState<string[]>(selectedFilters);
+  const [symptomOptions, setSymptomOptions] = useState<string[]>([]);
+  const [moodOptions, setMoodOptions] = useState<string[]>([]);
+  const [medicationOptions, setMedicationOptions] = useState<string[]>([]);
+  const [birthControlOptions, setBirthControlOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!visible) return;
+
+    const fetchSymptoms = async () => {
+      const symptoms = await getAllSymptoms();
+      setSymptomOptions(
+        symptoms
+          .filter((symptom) => symptom.visible)
+          .map((symptom) => symptom.name),
+      );
+    };
+
+    const fetchMoods = async () => {
+      const moods = await getAllMoods();
+      setMoodOptions(
+        moods.filter((mood) => mood.visible).map((mood) => mood.name),
+      );
+    };
+
+    const fetchMedications = async () => {
+      const medications = await getAllMedications();
+      setMedicationOptions(
+        medications
+          .filter((medication) => medication.visible)
+          .map((medication) => medication.name),
+      );
+    };
+
+    fetchSymptoms();
+    fetchMoods();
+    fetchMedications();
+
+    // change later!!!
+    setBirthControlOptions(bcData);
+  }, [visible]);
 
   useEffect(() => {
     setTempSelectedFilters(selectedFilters);

--- a/components/dayView/BirthControlAccordion.tsx
+++ b/components/dayView/BirthControlAccordion.tsx
@@ -1,8 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { View, Modal, Platform } from "react-native";
 import { List, Text, Button, TextInput } from "react-native-paper";
 import DateTimePicker from "@react-native-community/datetimepicker";
-import { birthControlOptions } from "@/constants/BirthControlTypes";
+import { getAllVisibleMedications } from "@/db/database";
 import SingleChipSelection from "./SingleChipSelection";
 import { useTheme } from "react-native-paper";
 import {
@@ -24,11 +24,24 @@ export default function BirthControlAccordion({
   setSelectedBirthControl: (birthControl: string | null) => void;
 }) {
   const theme = useTheme();
+  const [birthControlOptions, setBirthControlOptions] = useState<string[]>([]);
 
   const { showTimePicker, setShowTimePicker } = useTimePickerState();
   const { tempSelectedTime, setTempSelectedTime } = useTempSelectedTime();
   const { timeTaken, setTimeTaken } = useTimeTaken();
   const { birthControlNotes, setBirthControlNotes } = useBirthControlNotes();
+
+  useEffect(() => {
+    const fetchMedications = async () => {
+      const medications = await getAllVisibleMedications();
+      setBirthControlOptions(
+        medications
+          .filter((medication) => medication.type === "birth control")
+          .map((medication) => medication.name),
+      );
+    };
+    fetchMedications();
+  }, [state]);
 
   useEffect(() => {
     if (selectedBirthControl !== "Pill") {

--- a/components/dayView/MedicationsAccordion.tsx
+++ b/components/dayView/MedicationsAccordion.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState } from "react";
 import { List } from "react-native-paper";
-import { medicationOptions } from "@/constants/Medications";
+import { getAllVisibleMedications } from "@/db/database";
 import ChipSelection from "./ChipSelection";
 import { birthControlOptions } from "@/constants/BirthControlTypes";
 
@@ -14,9 +15,24 @@ export default function MedicationsAccordion({
   selectedMedications: string[];
   setSelectedMedications: (medications: string[]) => void;
 }) {
-  // Filter out birth control medications to calculate the count
+  const [medicationOptions, setMedicationOptions] = useState<string[]>([]);
+  useEffect(() => {
+    const fetchMedications = async () => {
+      const medications = await getAllVisibleMedications();
+      setMedicationOptions(
+        medications
+          .filter((medication) => medication.type !== "birth control")
+          .map((medication) => medication.name),
+      );
+    };
+    fetchMedications();
+  }, [state]);
+
+  // Filter out birth control medications and only include visible medications to calculate the count
   const medicationsWithoutBirthControl = selectedMedications.filter(
-    (medication) => !birthControlOptions.includes(medication),
+    (medication) =>
+      !birthControlOptions.includes(medication) &&
+      medicationOptions.includes(medication),
   );
 
   return (

--- a/components/dayView/MoodsAccordion.tsx
+++ b/components/dayView/MoodsAccordion.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState } from "react";
 import { List } from "react-native-paper";
-import { moodOptions } from "@/constants/Moods";
+import { getAllVisibleMoods } from "@/db/database";
 import ChipSelection from "./ChipSelection";
 
 export default function MoodsAccordion({
@@ -13,9 +14,23 @@ export default function MoodsAccordion({
   selectedMoods: string[];
   setSelectedMoods: (moods: string[]) => void;
 }) {
+  const [moodOptions, setMoodOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchMoods = async () => {
+      const moods = await getAllVisibleMoods();
+      setMoodOptions(moods.map((mood) => mood.name));
+    };
+    fetchMoods();
+  }, [state]);
+
+  const selectedVisibleMoods = selectedMoods.filter((mood) =>
+    moodOptions.includes(mood),
+  );
+
   return (
     <List.Accordion
-      title={"Moods   |   " + selectedMoods.length + " Selected"}
+      title={"Moods   |   " + selectedVisibleMoods.length + " Selected"}
       expanded={state === "mood"}
       onPress={() => setExpandedAccordion(state === "mood" ? null : "mood")}
       left={(props) => <List.Icon {...props} icon="emoticon" />}

--- a/components/dayView/SymptomsAccordion.tsx
+++ b/components/dayView/SymptomsAccordion.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { List } from "react-native-paper";
 import ChipSelection from "./ChipSelection";
-import { getAllSymptoms } from "@/db/database";
+import { getAllVisibleSymptoms } from "@/db/database";
 
 export default function SymptomsAccordion({
   state,
@@ -18,19 +18,19 @@ export default function SymptomsAccordion({
 
   useEffect(() => {
     const fetchSymptoms = async () => {
-      const symptoms = await getAllSymptoms();
-      setSymptomOptions(
-        symptoms
-          .filter((symptom) => symptom.visible)
-          .map((symptom) => symptom.name),
-      );
+      const symptoms = await getAllVisibleSymptoms();
+      setSymptomOptions(symptoms.map((symptom) => symptom.name));
     };
     fetchSymptoms();
   }, [state]);
 
+  const selectedVisibleSymptoms = selectedSymptoms.filter((symptom) =>
+    symptomOptions.includes(symptom),
+  );
+
   return (
     <List.Accordion
-      title={"Symptoms   |   " + selectedSymptoms.length + " Selected"}
+      title={"Symptoms   |   " + selectedVisibleSymptoms.length + " Selected"}
       expanded={state === "symptoms"}
       onPress={() =>
         setExpandedAccordion(state === "symptoms" ? null : "symptoms")

--- a/components/dayView/SymptomsAccordion.tsx
+++ b/components/dayView/SymptomsAccordion.tsx
@@ -1,6 +1,7 @@
+import { useEffect, useState } from "react";
 import { List } from "react-native-paper";
 import ChipSelection from "./ChipSelection";
-import { symptomOptions } from "@/constants/Symptoms";
+import { getAllSymptoms } from "@/db/database";
 
 export default function SymptomsAccordion({
   state,
@@ -13,6 +14,20 @@ export default function SymptomsAccordion({
   selectedSymptoms: string[];
   setSelectedSymptoms: (symptoms: string[]) => void;
 }) {
+  const [symptomOptions, setSymptomOptions] = useState<string[]>([]);
+
+  useEffect(() => {
+    const fetchSymptoms = async () => {
+      const symptoms = await getAllSymptoms();
+      setSymptomOptions(
+        symptoms
+          .filter((symptom) => symptom.visible)
+          .map((symptom) => symptom.name),
+      );
+    };
+    fetchSymptoms();
+  }, [state]);
+
   return (
     <List.Accordion
       title={"Symptoms   |   " + selectedSymptoms.length + " Selected"}

--- a/components/settings/AuthenticationSettings.tsx
+++ b/components/settings/AuthenticationSettings.tsx
@@ -292,9 +292,13 @@ export default function AuthenticationSettings() {
 
   return (
     <ThemedView>
-      <Divider style={{ marginTop: 10 }} />
       <List.Section>
-        <List.Accordion title="Lock App Behind Authentication">
+        <List.Accordion
+          title="Lock App Behind Authentication"
+          titleStyle={{
+            fontSize: 20,
+          }}
+        >
           <RadioButton.Group
             value={selectedAuth}
             onValueChange={handleOptionChange}

--- a/components/settings/Customization.tsx
+++ b/components/settings/Customization.tsx
@@ -265,7 +265,6 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
 }
 
 export default function Customization() {
-  const theme = useTheme();
   const [calendarEntriesModalVisible, setCalendarEntriesModalVisible] =
     useState(false);
 

--- a/components/settings/Customization.tsx
+++ b/components/settings/Customization.tsx
@@ -25,6 +25,7 @@ import { ScrollView, StyleSheet, Dimensions } from "react-native";
 import {
   useAccordion,
   useCalendarFilters,
+  useDatabaseChangeNotifier,
 } from "@/assets/src/calendar-storage";
 
 export interface Symptom {
@@ -90,6 +91,7 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
   const theme = useTheme();
   const { width, height } = Dimensions.get("window");
   const styles = makeStyles(theme, width, height);
+  const setDbChange = useDatabaseChangeNotifier().setDatabaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
   const setAccordionState = useAccordion().setExpandedAccordion;
   const [expanded, setExpanded] = useState<string>("1");
@@ -192,6 +194,8 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
     // this closes any open accordions on the calendar page,
     // which will force them to re-render with the updated data
     setAccordionState(null);
+    // force useLiveQuery to update
+    setDbChange(Math.random().toString());
     onDismiss();
   };
 

--- a/components/settings/Customization.tsx
+++ b/components/settings/Customization.tsx
@@ -1,0 +1,327 @@
+import { useState, useEffect } from "react";
+import {
+  getAllSymptoms,
+  getAllMoods,
+  getAllMedications,
+  updateSymptom,
+  updateMood,
+  updateMedication,
+  updateSetting,
+} from "@/db/database";
+import { SettingsKeys } from "@/constants/Settings";
+import { ThemedView } from "@/components/ThemedView";
+import {
+  Text,
+  List,
+  Divider,
+  useTheme,
+  Modal,
+  Portal,
+  IconButton,
+  Switch,
+  MD3Theme,
+} from "react-native-paper";
+import { ScrollView, StyleSheet, Dimensions } from "react-native";
+import {
+  useAccordion,
+  useCalendarFilters,
+} from "@/assets/src/calendar-storage";
+
+export interface Symptom {
+  id: number;
+  name: string;
+  visible?: boolean;
+  description?: string;
+}
+
+export interface Mood {
+  id: number;
+  name: string;
+  visible?: boolean;
+  description?: string;
+}
+
+export interface Medication {
+  id: number;
+  name: string;
+  dose?: string;
+  visible?: boolean;
+  type?: string;
+  description?: string;
+}
+
+function AccordionContents({
+  items,
+  itemType,
+  onToggleSwitch,
+}: {
+  items: Symptom[] | Mood[] | Medication[];
+  itemType: string;
+  onToggleSwitch: (
+    entryType: string,
+    entry: Symptom | Mood | Medication,
+  ) => void;
+}) {
+  const theme = useTheme();
+  const { width, height } = Dimensions.get("window");
+  const styles = makeStyles(theme, width, height);
+
+  return (
+    <ScrollView style={styles.scrollview}>
+      {items.map((item) => (
+        <List.Item
+          key={item.id}
+          title={item.name}
+          right={() => (
+            <Switch
+              value={item.visible === true}
+              onValueChange={() => {
+                onToggleSwitch(itemType, item);
+              }}
+            />
+          )}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
+  const theme = useTheme();
+  const { width, height } = Dimensions.get("window");
+  const styles = makeStyles(theme, width, height);
+  const { selectedFilters, setSelectedFilters } = useCalendarFilters();
+  const setAccordionState = useAccordion().setExpandedAccordion;
+  const [expanded, setExpanded] = useState<string>("1");
+  const [symptoms, setSymptoms] = useState<Symptom[]>([]);
+  const [moods, setMoods] = useState<Mood[]>([]);
+  const [medications, setMedications] = useState<Medication[]>([]);
+  const [birthControl, setBirthControl] = useState<Medication[]>([]);
+
+  useEffect(() => {
+    const fetchSymptoms = async () => {
+      const symptoms = await getAllSymptoms();
+      setSymptoms(symptoms as Symptom[]);
+    };
+    const fetchMoods = async () => {
+      const moods = await getAllMoods();
+      setMoods(moods as Mood[]);
+    };
+    const fetchMedications = async () => {
+      const medications = await getAllMedications();
+      setMedications(
+        medications.filter(
+          (medication) => medication.type !== "birth control",
+        ) as Medication[],
+      );
+      setBirthControl(
+        medications.filter(
+          (medication) => medication.type === "birth control",
+        ) as Medication[],
+      );
+    };
+
+    fetchSymptoms();
+    fetchMoods();
+    fetchMedications();
+  }, []);
+
+  const onToggleSwitch = (
+    entryType: string,
+    entry: Symptom | Mood | Medication,
+  ) => {
+    switch (entryType) {
+      case "symptom":
+        updateSymptom(entry.name, !entry.visible);
+        setSymptoms(
+          symptoms.map((symptom) =>
+            symptom.id === entry.id
+              ? { ...symptom, visible: !symptom.visible }
+              : symptom,
+          ),
+        );
+        break;
+      case "mood":
+        updateMood(entry.name, !entry.visible);
+        setMoods(
+          moods.map((mood) =>
+            mood.id === entry.id ? { ...mood, visible: !mood.visible } : mood,
+          ),
+        );
+        break;
+      case "medication":
+        if ("type" in entry) {
+          updateMedication(entry.name, !entry.visible, entry.type);
+          setMedications(
+            medications.map((medication) =>
+              medication.id === entry.id
+                ? { ...medication, visible: !medication.visible }
+                : medication,
+            ),
+          );
+        }
+        break;
+      case "birth control":
+        if ("type" in entry) {
+          updateMedication(entry.name, !entry.visible, entry.type);
+          setBirthControl(
+            birthControl.map((medication) =>
+              medication.id === entry.id
+                ? { ...medication, visible: !medication.visible }
+                : medication,
+            ),
+          );
+        }
+        break;
+    }
+
+    // check if entry is in calendar filters and remove if needed
+    if (selectedFilters.includes(entry.name) && entry.visible) {
+      const updatedFilters = selectedFilters.filter(
+        (filter: string) => filter !== entry.name,
+      );
+      setSelectedFilters(updatedFilters);
+      updateSetting(
+        SettingsKeys.calendarFilters,
+        JSON.stringify(selectedFilters),
+      );
+    }
+  };
+
+  const onDismissModal = () => {
+    // this closes any open accordions on the calendar page,
+    // which will force them to re-render with the updated data
+    setAccordionState(null);
+    onDismiss();
+  };
+
+  return (
+    <Portal>
+      <Modal visible={true} onDismiss={() => {}} style={styles.modal}>
+        <ThemedView style={styles.modalContentContainer}>
+          <ThemedView style={styles.modalTitleContainer}>
+            <IconButton icon="arrow-left" onPress={onDismissModal} />
+            <Text variant="titleLarge" style={styles.modalTitle}>
+              Calendar Entries
+            </Text>
+          </ThemedView>
+          <List.AccordionGroup
+            expandedId={expanded}
+            onAccordionPress={(expandedId) => setExpanded(String(expandedId))}
+          >
+            <List.Accordion
+              title="Symptom Entries"
+              id="1"
+              titleStyle={styles.listTitle}
+            >
+              <AccordionContents
+                items={symptoms}
+                itemType="symptom"
+                onToggleSwitch={onToggleSwitch}
+              />
+            </List.Accordion>
+            <Divider />
+            <List.Accordion
+              title="Mood Entries"
+              id="2"
+              titleStyle={styles.listTitle}
+            >
+              <AccordionContents
+                items={moods}
+                itemType="mood"
+                onToggleSwitch={onToggleSwitch}
+              />
+            </List.Accordion>
+            <Divider />
+            <List.Accordion
+              title="Medication Entries"
+              id="3"
+              titleStyle={styles.listTitle}
+            >
+              <AccordionContents
+                items={medications}
+                itemType="medication"
+                onToggleSwitch={onToggleSwitch}
+              />
+            </List.Accordion>
+            <Divider />
+            <List.Accordion
+              title="Birth Control Entries"
+              id="4"
+              titleStyle={styles.listTitle}
+            >
+              <AccordionContents
+                items={birthControl}
+                itemType="birth control"
+                onToggleSwitch={onToggleSwitch}
+              />
+            </List.Accordion>
+            <Divider />
+          </List.AccordionGroup>
+        </ThemedView>
+      </Modal>
+    </Portal>
+  );
+}
+
+export default function Customization() {
+  const theme = useTheme();
+  const [calendarEntriesModalVisible, setCalendarEntriesModalVisible] =
+    useState(false);
+
+  return (
+    <ThemedView>
+      <List.Section>
+        <List.Accordion
+          title="Customization"
+          titleStyle={{
+            fontSize: 20,
+          }}
+        >
+          <List.Item
+            title="Calendar Entries"
+            description="Choose what's visible on the calendar"
+            onPress={() => setCalendarEntriesModalVisible(true)}
+            right={(props) => <List.Icon {...props} icon="arrow-right" />}
+          />
+        </List.Accordion>
+      </List.Section>
+      <Divider />
+      {calendarEntriesModalVisible && (
+        <CalendarEntriesModal
+          onDismiss={() => setCalendarEntriesModalVisible(false)}
+        />
+      )}
+    </ThemedView>
+  );
+}
+
+const makeStyles = (theme: MD3Theme, width: number, height: number) => {
+  return StyleSheet.create({
+    modal: {
+      justifyContent: "flex-start",
+      height: "100%",
+    },
+    modalTitleContainer: {
+      backgroundColor: theme.colors.primaryContainer,
+      padding: 5,
+      alignItems: "center",
+      flexDirection: "row",
+    },
+    modalTitle: {
+      textAlign: "center",
+      fontWeight: "bold",
+      color: theme.colors.onPrimaryContainer,
+    },
+    modalContentContainer: {
+      height: "100%",
+    },
+    listTitle: {
+      fontSize: 20,
+    },
+    scrollview: {
+      maxHeight: height * 0.5,
+      boxShadow: "inset 0 7px 9px -7px rgba(0,0,0,0.2)",
+    },
+  });
+};

--- a/components/settings/DeleteData.tsx
+++ b/components/settings/DeleteData.tsx
@@ -51,7 +51,12 @@ export default function DeleteData() {
   return (
     <ThemedView>
       <List.Section>
-        <List.Accordion title="Delete Data">
+        <List.Accordion
+          title="Delete Data"
+          titleStyle={{
+            fontSize: 20,
+          }}
+        >
           <View style={{ paddingLeft: 15, paddingRight: 15, gap: 10 }}>
             <Text>
               Data is stored only on this device and cannot be recovered once

--- a/components/settings/PrivacyPolicy.tsx
+++ b/components/settings/PrivacyPolicy.tsx
@@ -7,7 +7,12 @@ export default function PrivacyPolicy() {
   return (
     <ThemedView style={{ height: "100%" }}>
       <List.Section>
-        <List.Accordion title="Privacy Policy">
+        <List.Accordion
+          title="Privacy Policy"
+          titleStyle={{
+            fontSize: 20,
+          }}
+        >
           <List.Item
             title="About Us"
             description={

--- a/constants/Interfaces.ts
+++ b/constants/Interfaces.ts
@@ -96,3 +96,8 @@ export interface CalendarFilters {
   selectedFilters: string[];
   setSelectedFilters: (values: string[]) => void;
 }
+
+export interface DatabaseChangeNotifier {
+  databaseChange: string;
+  setDatabaseChange: (databaseChange: string) => void;
+}

--- a/db/database.ts
+++ b/db/database.ts
@@ -12,6 +12,7 @@ import { insertMedication } from "@/db/operations/medications";
 import { symptomOptions } from "@/constants/Symptoms";
 import { moodOptions } from "@/constants/Moods";
 import { medicationOptions } from "@/constants/Medications";
+import { birthControlOptions } from "@/constants/BirthControlTypes";
 import { getSetting, updateSetting } from "@/db/operations/settings";
 import { SettingsKeys } from "@/constants/Settings";
 
@@ -50,6 +51,9 @@ export const setupEntryTypes = async () => {
   }
   for (const medication of medicationOptions) {
     await insertMedication(medication, true);
+  }
+  for (const birthControl of birthControlOptions) {
+    await insertMedication(birthControl, true, "birth control");
   }
 
   // update calendar filters

--- a/hooks/useFetchMedicationEntries.ts
+++ b/hooks/useFetchMedicationEntries.ts
@@ -42,7 +42,7 @@ export function useFetchMedicationEntries(
     }[];
 
     const birthControlEntry = filteredValues.find((value) =>
-      birthControlOptions.some((option) => option.value === value.name),
+      birthControlOptions.some((option) => option === value.name),
     );
 
     if (birthControlEntry) {
@@ -57,8 +57,7 @@ export function useFetchMedicationEntries(
 
     const medicationsWithoutBirthControl = filteredValues
       .filter(
-        (value) =>
-          !birthControlOptions.some((option) => option.value === value.name),
+        (value) => !birthControlOptions.some((option) => option === value.name),
       )
       .map((value) => value.name);
 


### PR DESCRIPTION
I made a new `settings` folder in `src/components` that I moved existing settings views into. I added a `Customization` dropdown that for now only has one item (entry visibility), but will eventually also hold the option for adding custom entries. 

Users can use the toggles to choose what shows up in the `DayView` accordions and `CalendarFilterDialog`. If an entry is being filtered on the calendar, toggling it invisible will remove it. Invisible entries also won't show up under the `AnySymptom`, `AnyMood`, etc. filters. I had to add a store value to trigger the `useLiveQuery` to refresh when the modal makes changes, since it wouldn't consistently catch the visibility changes to the database. This store value is used to trigger an update in the `CalendarFilterDialog` as well. 