### PR TITLE
Home Page Contrast

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -115,5 +115,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "bold",
     textAlign: "center",
+    textShadowColor: "black",
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 3,
   },
 });

--- a/components/FlowChart.tsx
+++ b/components/FlowChart.tsx
@@ -54,7 +54,7 @@ export default function FlowChart() {
 
       const markColor = FlowColors[data.flow_intensity ?? 0];
 
-      return <Circle key={index} cx={x} cy={y} r="5" fill={markColor} stroke={theme.colors.onSecondary} strokeWidth="0.5" />;
+      return <Circle key={index} cx={x} cy={y} r="5" fill={markColor} stroke={theme.colors.onSecondary} strokeWidth="0.5" />; //
     });
   };
 
@@ -159,20 +159,6 @@ export default function FlowChart() {
   return (
     <View style={{ padding: 2 }}>
       <Svg height={height * 0.5} width="100%" viewBox="-5 -5 110 110">
-      {/* <Circle
-          cx="50"
-          cy="50"
-          r="55"
-          fill={theme.colors.inverseSurface}
-          strokeWidth="8"
-        /> */}
-        <Circle
-          cx="50"
-          cy="50"
-          r="35"
-          fill={theme.colors.secondaryContainer}
-          strokeWidth="8"
-        />
         <Path
           d={arcPath}
           fill="transparent"
@@ -180,7 +166,13 @@ export default function FlowChart() {
           strokeWidth="9"
           strokeLinecap="round"
         />
-        
+        <Circle
+          cx="50"
+          cy="50"
+          r="35"
+          fill={theme.colors.secondaryContainer}
+          strokeWidth="8"
+        />
         <Text
           fill={theme.colors.onSecondaryContainer}
           fontSize="10"

--- a/components/FlowChart.tsx
+++ b/components/FlowChart.tsx
@@ -54,7 +54,7 @@ export default function FlowChart() {
 
       const markColor = FlowColors[data.flow_intensity ?? 0];
 
-      return <Circle key={index} cx={x} cy={y} r="5" fill={markColor} />;
+      return <Circle key={index} cx={x} cy={y} r="5" fill={markColor} stroke={theme.colors.onSecondary} strokeWidth="0.5" />;
     });
   };
 
@@ -159,13 +159,13 @@ export default function FlowChart() {
   return (
     <View style={{ padding: 2 }}>
       <Svg height={height * 0.5} width="100%" viewBox="-5 -5 110 110">
-        <Path
-          d={arcPath}
-          fill="transparent"
-          stroke={theme.colors.secondary}
-          strokeWidth="9"
-          strokeLinecap="round"
-        />
+      {/* <Circle
+          cx="50"
+          cy="50"
+          r="55"
+          fill={theme.colors.inverseSurface}
+          strokeWidth="8"
+        /> */}
         <Circle
           cx="50"
           cy="50"
@@ -173,6 +173,14 @@ export default function FlowChart() {
           fill={theme.colors.secondaryContainer}
           strokeWidth="8"
         />
+        <Path
+          d={arcPath}
+          fill="transparent"
+          stroke={theme.colors.secondary}
+          strokeWidth="9"
+          strokeLinecap="round"
+        />
+        
         <Text
           fill={theme.colors.onSecondaryContainer}
           fontSize="10"

--- a/components/FlowChart.tsx
+++ b/components/FlowChart.tsx
@@ -54,7 +54,17 @@ export default function FlowChart() {
 
       const markColor = FlowColors[data.flow_intensity ?? 0];
 
-      return <Circle key={index} cx={x} cy={y} r="5" fill={markColor} stroke={theme.colors.onSecondary} strokeWidth="0.5" />; //
+      return (
+        <Circle
+          key={index}
+          cx={x}
+          cy={y}
+          r="5"
+          fill={markColor}
+          stroke={theme.colors.onSecondary}
+          strokeWidth="0.5"
+        />
+      ); //
     });
   };
 


### PR DESCRIPTION
Added outlines to the markings on the flow chart to make them more distinct from the chart's ring as well as shadows to the text on the flow logs to increase contrast between colors on the home page.
![newflow](https://github.com/user-attachments/assets/9cdb6625-8caa-4fec-b113-c26fb02c7346)