### PR TITLE
fixed selected time issue

### DIFF
--- a/hooks/useSyncMedicationEntries.ts
+++ b/hooks/useSyncMedicationEntries.ts
@@ -37,8 +37,8 @@ export function useSyncMedicationEntries(date: string) {
         }
         if (item) {
           const isBirthControl = birthControlOptions.find(
-            (option: string ) => option === value
-          )
+            (option: string) => option === value,
+          );
           if (isBirthControl) {
             await insertEntry(day.id, item.id, time_taken, notes);
           } else {

--- a/hooks/useSyncMedicationEntries.ts
+++ b/hooks/useSyncMedicationEntries.ts
@@ -37,8 +37,8 @@ export function useSyncMedicationEntries(date: string) {
         }
         if (item) {
           const isBirthControl = birthControlOptions.find(
-            (option: { value: string }) => option.value === value,
-          );
+            (option: string ) => option === value
+          )
           if (isBirthControl) {
             await insertEntry(day.id, item.id, time_taken, notes);
           } else {


### PR DESCRIPTION
Fixed the bug where selected time for taking the pill wouldn't be entered into the DB on save. 

Was just a small issue, within useSyncMedicationEntries.tsx it wasn't correctly determining if a medication entry was birth control or a general medication, which was causing the birth control input to be entered into the db as insertEntry(day.id, item.id), instead of insertEntry(day.id, item.id, time_taken, notes). 

This also fixes the functionality of birth control notes, as I discovered that was also broken.