### PR TITLE
Expo Build Workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+  Does this PR require a mobile build? If so, make sure that you have updated the expo.version number in the app.json file (e.g., 1.2.0 -> 1.3.0)! Expo uses this number for versioning the builds.
+  The version format is MAJOR.MINOR.PATCH
+    MAJOR: Large/breaking change
+    MINOR: New feature(s)
+    PATCH: A bug fix
+
+  If this PR won't need a mobile build (e.g. documentation update only or it's going to be batched into a later build), remove the build reminder below.
+-->
+
+### Build Reminder (for reviewers)
+
+This PR requires a mobile build for <!-- Choose one of these options and erase the others: --> Android | iOS | both platforms
+
+- Confirm that the `app.json` version has been updated and matches versioning format
+- After merging, go to `Actions` -> `Manual EAS Expo Build` -> `Run workflow` dropdown -> Choose appropriate platform(s) -> `Run workflow`

--- a/.github/workflows/manual-eas-build.yml
+++ b/.github/workflows/manual-eas-build.yml
@@ -1,0 +1,51 @@
+name: Manual Expo EAS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Which platform to build?"
+        required: true
+        default: "both"
+        type: choice
+        options:
+          - both
+          - android
+          - ios
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build app
+        run: |
+          if [[ "${{ github.event.inputs.platform }}" == "android" ]]; then
+            echo "Building Android only..."
+            eas build --platform android --non-interactive --profile production
+          elif [[ "${{ github.event.inputs.platform }}" == "ios" ]]; then
+            echo "Building iOS only..."
+            eas build --platform ios --non-interactive --profile production
+          else
+            echo "Building both Android and iOS..."
+            eas build --platform android --non-interactive --profile production
+            eas build --platform ios --non-interactive --profile production
+          fi

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "ephira",
     "slug": "ephira",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "orientation": "portrait",
     "scheme": "myapp",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
This PR adds a Github Actions Workflow that will allow us to run Android/iOS/both builds from the Github Actions tab. It also adds a PR template that reminds the user to update the version number in `app.json` if necessary, and reminds the reviewers to run the build if needed. The Expo Tokens still need to be created and added to GH, so it's a draft PR only for now. I've included screenshots below of this running on a test project. 

![image](https://github.com/user-attachments/assets/83e2f5ad-1a7f-481f-9ee3-b84623749a0f)
![image](https://github.com/user-attachments/assets/ba9f9b9e-ed98-469e-8bda-f0775805722e)
![image](https://github.com/user-attachments/assets/2a683c06-d413-4613-81f2-997264245422)



I've bumped the `app.json` version from `1.0.0` -> `1.1.0` to include the new features/bugs since our last mobile build:
* New features
  * Custom entries
* Small changes/bug fixes
  * Fade transition between screens
  * iOS icons update
  * Improve contrast on home page
  * Increased navbar spacing
  * Time/Notes not saving to DB bug fixed


This is what will show up for PRs that need a mobile build (such as this one):

### Build Reminder (for reviewers)

This PR requires a mobile build for <!-- Choose one of these options and erase the others: -->both platforms

- Confirm that the `app.json` version has been updated and matches versioning format
- After merging, go to `Actions` -> `Manual EAS Expo Build` -> `Run workflow` dropdown -> Choose appropriate platform(s) -> `Run workflow`
