### PR TITLE
Removed accordion label text, cleaned up spacing, and fixed iOS navbar

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -66,7 +66,7 @@ export default function TabLayout() {
             // Use a transparent background on iOS to show the blur effect
             position: "absolute",
             paddingBottom: 6,
-            paddingTop: 2,
+            paddingTop: 6,
             height: 60,
           },
           default: {

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -183,7 +183,7 @@ const makeStyles = ({ theme }: { theme: MD3Theme }) =>
       paddingTop: StatusBar.currentHeight,
       // Since iOS bar uses absolute positon for blur affect, we have to adjust padding to bottom of container
       paddingBottom: Platform.select({
-        ios: 70,
+        ios: 60,
         default: 0,
       }),
     },

--- a/components/dayView/BirthControlAccordion.tsx
+++ b/components/dayView/BirthControlAccordion.tsx
@@ -89,7 +89,7 @@ export default function BirthControlAccordion({
         placeholder="Enter reminders, appointments, etc."
         value={birthControlNotes}
         onChangeText={setBirthControlNotes}
-        style={{ width: "90%" }}
+        style={{ width: "90%", marginBottom: 24 }}
       />
     </View>
   );
@@ -224,7 +224,7 @@ export default function BirthControlAccordion({
         options={birthControlOptions}
         selectedValue={selectedBirthControl}
         setSelectedValue={setSelectedBirthControl}
-        label="Select Birth Control:"
+        label="Select Birth Control"
       />
       {renderBirthControlUI()}
     </List.Accordion>

--- a/components/dayView/ChipSelection.tsx
+++ b/components/dayView/ChipSelection.tsx
@@ -15,7 +15,7 @@ export default function ChipSelection({
   const theme = useTheme();
 
   return (
-    <View style={{ padding: 16 }}>
+    <View>
       <Text style={styles.sectionLabel}>{label}</Text>
       <View style={styles.chipContainer}>
         {options.map((option) => (
@@ -57,12 +57,14 @@ export default function ChipSelection({
 
 const styles = StyleSheet.create({
   chipContainer: {
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingBottom: 16,
+    paddingTop: 8,
     flexDirection: "row",
     flexWrap: "wrap",
   },
   sectionLabel: {
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 8,
+    display: "none",
   },
 });

--- a/components/dayView/MoodsAccordion.tsx
+++ b/components/dayView/MoodsAccordion.tsx
@@ -39,7 +39,7 @@ export default function MoodsAccordion({
         options={moodOptions}
         selectedValues={selectedMoods}
         setSelectedValues={setSelectedMoods}
-        label="Select Moods:"
+        label="Select Moods"
       />
     </List.Accordion>
   );

--- a/components/dayView/SingleChipSelection.tsx
+++ b/components/dayView/SingleChipSelection.tsx
@@ -15,7 +15,7 @@ export default function SingleChipSelection({
   const theme = useTheme();
 
   return (
-    <View style={{ padding: 16 }}>
+    <View>
       <Text style={styles.sectionLabel}>{label}</Text>
       <View style={styles.chipContainer}>
         {options.map((option) => (
@@ -55,12 +55,14 @@ export default function SingleChipSelection({
 
 const styles = StyleSheet.create({
   chipContainer: {
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingBottom: 16,
+    paddingTop: 8,
     flexDirection: "row",
     flexWrap: "wrap",
   },
   sectionLabel: {
-    fontSize: 16,
-    fontWeight: "600",
-    marginBottom: 8,
+    display: "none",
   },
 });

--- a/components/dayView/SymptomsAccordion.tsx
+++ b/components/dayView/SymptomsAccordion.tsx
@@ -41,7 +41,7 @@ export default function SymptomsAccordion({
         options={symptomOptions}
         selectedValues={selectedSymptoms}
         setSelectedValues={setSelectedSymptoms}
-        label="Select Symptoms:"
+        label="Select Symptoms"
       />
     </List.Accordion>
   );


### PR DESCRIPTION
## Accordion Changes:

### Symptoms:

<img src="https://github.com/user-attachments/assets/deb6fb89-3ed9-41b6-a224-bf84369a4cc8" width="300">
<img src="https://github.com/user-attachments/assets/699e2cda-038e-4f79-919c-19607c53f2a6" width="300">

### Moods: 

<img src="https://github.com/user-attachments/assets/31e24131-273a-4e57-8e1c-3f2d11fc45e1" width="300">
<img src="https://github.com/user-attachments/assets/7eb57d01-e66c-47d8-bdf9-5014943b591e" width="300">

### Birth Control Note:

<img src="https://github.com/user-attachments/assets/8306783a-26f6-4c26-8eb7-9f65a61903e2" width="300">
<img src="https://github.com/user-attachments/assets/9509c2d1-d78b-478d-b27c-70899bf21564" width="300">

### Medication:

I forgot to take a before image for medication accordion
<img src="https://github.com/user-attachments/assets/18afaf0b-b346-42ca-b36c-9d2cfa14a8dc" width="300">

## iOS NavBar Height

NavBar height would extend past the line

<img src="https://github.com/user-attachments/assets/e33454aa-bd41-49e7-a634-8b88f19f3cff" width="300">
<img src="https://github.com/user-attachments/assets/57464385-4438-4565-8482-306242f2333d" width="300">

