### PR TITLE
Update project structure and readme files

### DIFF
--- a/PROJECTSTRUCTURE.md
+++ b/PROJECTSTRUCTURE.md
@@ -93,10 +93,20 @@ This document provides an overview of the project structure and key components o
 - [react-native-calendars](https://wix.github.io/react-native-calendars/docs/Intro) - Calendar
 - [Zustand](https://zustand.docs.pmnd.rs/getting-started/introduction) - State Management
 
-### Setup
+## Setup
 
-- Install dependencies
-- Download Expo Go app on your phone
-- Run `npx expo start` in the terminal
-- Scan the QR code with the Expo Go app (for Android), camera (for iOS), or enter the URL in the app (for emulator/iOS/Android)
+Due to using Expo SQLite for the database, this project will only run on mobile devices or emulators.
+
+- Download the repo
+- `npm install`
+- `npx expo start`
+
+In the output, you'll find options to open the app in a:
+
+- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
+- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
+- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
+- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
   - If you get an error about the app not being able to connect or taking longer than it should, try running `npx expo start --tunnel` in the terminal and scanning the QR code again.
+
+This project uses [file-based routing](https://docs.expo.dev/router/introduction).

--- a/PROJECTSTRUCTURE.md
+++ b/PROJECTSTRUCTURE.md
@@ -79,9 +79,9 @@ This document provides an overview of the project structure and key components o
   - Makes the [markedDates](https://wix.github.io/react-native-calendars/docs/Components/Calendar#markeddates) object for the calendar based on the user's calendar filters.
   - Utilizes `useLiveFilteredData.ts` to get the filtered data as it changes and updates the markedDates.
 - `useSyncEntries.ts`
-- Syncs entries for the selected date with the database.
+  - Syncs entries for the selected date with the database.
 - `useSyncMedicationEntries.ts`
-- Syncs medication entries for the selected date with the database.
+  - Syncs medication entries for the selected date with the database.
 
 ## Tools & Libraries
 

--- a/PROJECTSTRUCTURE.md
+++ b/PROJECTSTRUCTURE.md
@@ -110,3 +110,7 @@ In the output, you'll find options to open the app in a:
   - If you get an error about the app not being able to connect or taking longer than it should, try running `npx expo start --tunnel` in the terminal and scanning the QR code again.
 
 This project uses [file-based routing](https://docs.expo.dev/router/introduction).
+
+## CI/CD
+
+Ephira is currently published on both Google Play and the Apple App Store. The app is built using [EAS Build](https://docs.expo.dev/build/introduction/), which can be manually triggered via [this Github Action](https://github.com/adulbrich/ephira/actions/workflows/manual-eas-build.yml). After building, the app must be submitted to the app stores manually through their respective developer consoles.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 
 ![All Screens](https://github.com/user-attachments/assets/c795869d-a4fe-44a9-b520-d5d4561245b1)
 
-
 ![Color Themes Screens - 1920x1080](https://github.com/user-attachments/assets/30b38159-a8aa-47a8-92e1-7dbbeacd79b8)
 
 <p align="center" style="display: flex; justify-content: center; gap: 24px;">
@@ -60,7 +59,6 @@ Add and track custom symptoms, moods, medications, and more with a smooth, visua
 Protect your data with Face ID or a custom password unique to Ephira.
 
 ![Password Demo (Final-All)](https://github.com/user-attachments/assets/296864e6-ae4e-48ac-8ee8-b9ca0cd0f9e9)
-
 
 <!-- DEVELOPMENT GOALS -->
 
@@ -118,34 +116,7 @@ See `LICENSE.txt` for more information.
 
 ## Getting Started
 
-### Running the Project
-
-This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
-
-Due to using Expo SQLite for the database, this project will only run on mobile devices.
-
-- Download the repo
-- `npm install`
-- `npx expo start`
-- On your mobile phone (iOS or Android), download the Expo Go app and then scan the QR code in the terminal.
-
-In the output, you'll find options to open the app in a:
-
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
-
-This project uses [file-based routing](https://docs.expo.dev/router/introduction).
-
-### Learn more
-
-To learn more about the libraries we use, look at the following resources:
-
-- [Expo](https://docs.expo.dev/)
-- [React Native](https://reactnative.dev/)
-- [React Native Paper](https://reactnativepaper.com/)
-- [Drizzle (Expo SQLite)](https://orm.drizzle.team/docs/connect-expo-sqlite)
+Check out the [Project Structure](https://github.com/adulbrich/ephira/blob/main/PROJECTSTRUCTURE.md) document for an overview of the key components of the app, main libraries used, and how to set up the app locally.
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->


### PR DESCRIPTION
I moved removed the "Getting Started" section from the README and it now directs to the PROJECTSTRUCTURE file (I'm open to renaming this as well, the current name feels a little clunky). I also fixed some missing tabs and clarified the setup instructions based on what was in the README. 
