### PR TITLE
fix: import expo-file-system legacy API so export does not throw (#192)

### DIFF
--- a/components/settings/ExportData.tsx
+++ b/components/settings/ExportData.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { getAllDataAsJson } from "@/db/database";
-import * as FileSystem from "expo-file-system";
+import * as FileSystem from "expo-file-system/legacy";
 import * as Sharing from "expo-sharing";
 import { ThemedView } from "@/components/ThemedView";
 import {
@@ -30,10 +30,10 @@ async function exportCsvOrJson(data: string, fileType: string) {
   const UTI =
     fileType === "csv" ? "public.comma-separated-values-text" : "public.json";
   try {
-    const fileUri = FileSystem.cacheDirectory + fileName; //"import/namespace": "off"
+    const fileUri = FileSystem.cacheDirectory + fileName;
 
     await FileSystem.writeAsStringAsync(fileUri, data, {
-      encoding: FileSystem.EncodingType.UTF8, //"import/namespace": "off"
+      encoding: FileSystem.EncodingType.UTF8,
     });
 
     if (!(await Sharing.isAvailableAsync())) {

--- a/components/settings/PdfBuilder.ts
+++ b/components/settings/PdfBuilder.ts
@@ -1,5 +1,5 @@
 import { PDFDocument, StandardFonts, rgb, PDFPage, PDFFont } from "pdf-lib";
-import * as FileSystem from "expo-file-system";
+import * as FileSystem from "expo-file-system/legacy";
 import * as Sharing from "expo-sharing";
 import type { ExportData } from "../../constants/Interfaces";
 
@@ -97,9 +97,9 @@ function drawRowText(
 
 async function exportFinishedPdf(pdfDoc: PDFDocument) {
   const pdfBase64 = await pdfDoc.saveAsBase64();
-  const pdfPath = `${FileSystem.documentDirectory}ephira.pdf`; //"import/namespace": "off"
+  const pdfPath = `${FileSystem.documentDirectory}ephira.pdf`;
   await FileSystem.writeAsStringAsync(pdfPath, pdfBase64, {
-    encoding: FileSystem.EncodingType.Base64, //"import/namespace": "off"
+    encoding: FileSystem.EncodingType.Base64,
   });
 
   await Sharing.shareAsync(pdfPath, {


### PR DESCRIPTION
Fixes #192.

## What was broken

`expo-file-system@19` (SDK 54) made the new `File` / `Directory` API the default export and moved the old API to `expo-file-system/legacy`. Two things followed from that, and only one of them is visible in a type error:

- `cacheDirectory`, `documentDirectory` and `EncodingType` are simply gone from the default export. `FileSystem.cacheDirectory + fileName` evaluates to `"undefined/ephira_data.csv"`.
- The legacy function names that *do* remain are deprecation shims. `node_modules/expo-file-system/build/legacyWarnings.d.ts` documents `writeAsStringAsync` as *"This method will throw in runtime."*

So CSV, JSON and PDF export all fail for every user on the current release.

## The fix

`import * as FileSystem from "expo-file-system/legacy"` in both call sites. The legacy module exports all four names with identical signatures, so nothing else changes. Migrating to the new `File` API is a larger piece of work and is not needed to unbreak this.

Also removes four `//"import/namespace": "off"` comments. They were never ESLint directives — the quotes make them plain comments — and the rule is already disabled globally in `eslint.config.js:14`.

## Verification

```
$ npx tsc --noEmit
TSC EXIT: 0

$ npx eslint . --max-warnings=0
ESLINT EXIT: 0
```

Before this change `tsc --noEmit` reported four errors across these two files.

## Two notes for the reviewer

**Ordering.** This wants to merge before #178, which adds `tsc --noEmit` to CI. These four errors are the only ones in the repo, so #178 goes green once this lands.

**A convention worth a second look, separately.** `import/namespace` is off globally, which is exactly the rule that would have caught this during the SDK 54 upgrade. Turning it back on is a bigger change than this PR should carry — worth its own issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)