### PR TITLE
fix: reconcile prediction snapshots instead of re-inserting them (#179)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,7 +20,7 @@ This file is maintained lazily: terms are added when a design decision actually 
 
 **Prediction**: a forecast of a future Day with flow, carrying a confidence. Predictions are derived, never authored.
 
-**Prediction Snapshot**: a record of what was predicted, and when, kept so that accuracy can be measured after the fact. Identified by `(prediction_made_date, predicted_date)`. Its purpose is a time series: overwriting history would make the accuracy metric measure something else.
+**Prediction Snapshot**: a record of what was predicted, and when, kept so that accuracy can be measured after the fact. Identified by `(prediction_made_date, predicted_date)`. Its purpose is a time series: overwriting history would make the accuracy metric measure something else. Within a single day the stored generation is reconciled to what is currently forecast: confidence updates in place, and a date no longer forecast is retracted. Once a Snapshot's outcome has been measured it is never retracted and its outcome is never rewritten, because that is the history the metric reads.
 
 **Marked Dates**: the value handed to the calendar describing how each date should be drawn. Cycle mode encodes runs, with start and end caps, adjacency to neighbouring days, and confidence-scaled opacity for Prediction overlays. Pregnancy mode encodes point events. Both modes produce the same value type; they do not share the rules for building it.
 

--- a/db/__tests__/predictionSnapshots.test.ts
+++ b/db/__tests__/predictionSnapshots.test.ts
@@ -1,0 +1,169 @@
+import {
+  getPredictionAccuracy,
+  savePredictions,
+  checkPredictionAccuracy,
+} from "@/db/operations/predictionSnapshots";
+import { predictionSnapshots } from "@/db/schema";
+import {
+  getTestDatabase,
+  resetTestDatabase,
+} from "@/__tests__/helpers/testDatabase";
+
+jest.mock("@/db/operations/setup", () =>
+  jest.requireActual("@/__tests__/helpers/testDatabase"),
+);
+
+// UTC, because savePredictions formats with toISOString, matching the
+// convention services/cyclePredictionLogic.ts already uses for date strings.
+const MARCH_1 = new Date("2026-03-01T00:00:00Z");
+const MARCH_2 = new Date("2026-03-02T00:00:00Z");
+
+const storedSnapshots = () =>
+  getTestDatabase()
+    .select()
+    .from(predictionSnapshots)
+    .orderBy(
+      predictionSnapshots.prediction_made_date,
+      predictionSnapshots.predicted_date,
+    )
+    .all();
+
+beforeEach(() => {
+  resetTestDatabase();
+});
+
+describe("savePredictions", () => {
+  it("stores one row per predicted date", async () => {
+    await savePredictions(
+      [
+        { date: "2026-03-20", confidence: 80 },
+        { date: "2026-03-21", confidence: 75 },
+      ],
+      MARCH_1,
+    );
+
+    expect(storedSnapshots()).toHaveLength(2);
+  });
+
+  it("is idempotent: saving the same set twice changes nothing", async () => {
+    const predictions = [
+      { date: "2026-03-20", confidence: 80 },
+      { date: "2026-03-21", confidence: 75 },
+    ];
+
+    await savePredictions(predictions, MARCH_1);
+    const first = storedSnapshots();
+
+    await savePredictions(predictions, MARCH_1);
+
+    expect(storedSnapshots()).toEqual(first);
+  });
+
+  it("survives the calendar tapping that caused the defect", async () => {
+    const predictions = [{ date: "2026-03-20", confidence: 80 }];
+
+    for (let tap = 0; tap < 25; tap++) {
+      await savePredictions(predictions, MARCH_1);
+    }
+
+    expect(storedSnapshots()).toHaveLength(1);
+  });
+
+  it("updates confidence in place when the same day predicts again", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+    await savePredictions([{ date: "2026-03-20", confidence: 55 }], MARCH_1);
+
+    const stored = storedSnapshots();
+
+    expect(stored).toHaveLength(1);
+    expect(stored[0].confidence).toBe(55);
+  });
+
+  it("writes a new generation on a new day, preserving the time series", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+    await savePredictions([{ date: "2026-03-20", confidence: 90 }], MARCH_2);
+
+    const stored = storedSnapshots();
+
+    expect(stored).toHaveLength(2);
+    expect(stored.map((row) => row.prediction_made_date)).toEqual([
+      "2026-03-01",
+      "2026-03-02",
+    ]);
+  });
+
+  it("takes the prediction-made date from its caller, not the clock", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+
+    expect(storedSnapshots()[0].prediction_made_date).toBe("2026-03-01");
+  });
+
+  it("retracts same-day predictions that are no longer forecast", async () => {
+    await savePredictions(
+      [
+        { date: "2026-03-20", confidence: 80 },
+        { date: "2026-03-21", confidence: 75 },
+      ],
+      MARCH_1,
+    );
+
+    await savePredictions([{ date: "2026-03-21", confidence: 75 }], MARCH_1);
+
+    expect(storedSnapshots().map((row) => row.predicted_date)).toEqual([
+      "2026-03-21",
+    ]);
+  });
+
+  it("never retracts a prediction whose outcome has already been measured", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+    await checkPredictionAccuracy("2026-03-20", true);
+
+    await savePredictions([{ date: "2026-03-25", confidence: 60 }], MARCH_1);
+
+    const stored = storedSnapshots();
+
+    expect(stored.map((row) => row.predicted_date)).toEqual([
+      "2026-03-20",
+      "2026-03-25",
+    ]);
+    expect(stored[0].actual_had_flow).toBe(true);
+  });
+
+  it("leaves a measured outcome alone when confidence is updated", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+    await checkPredictionAccuracy("2026-03-20", true);
+
+    await savePredictions([{ date: "2026-03-20", confidence: 40 }], MARCH_1);
+
+    const [stored] = storedSnapshots();
+
+    expect(stored.confidence).toBe(40);
+    expect(stored.actual_had_flow).toBe(true);
+  });
+
+  it("keeps the accuracy metric from being skewed by repeated saves", async () => {
+    const predictions = [
+      { date: "2026-03-20", confidence: 80 },
+      { date: "2026-03-21", confidence: 75 },
+    ];
+
+    for (let tap = 0; tap < 10; tap++) {
+      await savePredictions(predictions, MARCH_1);
+    }
+
+    await checkPredictionAccuracy("2026-03-20", true);
+    await checkPredictionAccuracy("2026-03-21", false);
+
+    expect(await getPredictionAccuracy()).toEqual({
+      totalChecked: 2,
+      totalCorrect: 1,
+      accuracyPercentage: 50,
+    });
+  });
+
+  it("does nothing when given no predictions", async () => {
+    await savePredictions([], MARCH_1);
+
+    expect(storedSnapshots()).toEqual([]);
+  });
+});

--- a/db/operations/predictionSnapshots.ts
+++ b/db/operations/predictionSnapshots.ts
@@ -5,22 +5,78 @@ import { eq, and, isNull, desc } from "drizzle-orm";
 const db = getDrizzleDatabase();
 
 /**
- * Save a batch of predictions to the database
+ * Reconciles a generated set of predictions against what is already stored for
+ * the same day, so that running it twice changes nothing.
+ *
+ * `prediction_snapshots` exists to hold a time series: what was predicted, and
+ * when. Re-running on the same day is not new information, so it updates the
+ * existing generation in place; a new day writes a new one. Predictions the
+ * same day no longer forecasts are retracted, unless their outcome has already
+ * been measured, because rewriting a measured outcome would change what the
+ * accuracy metric is measuring.
+ *
+ * `predictionMadeDate` is a parameter rather than a clock read. Callers pass
+ * the same reference date they hand to `generatePredictions`, and it is
+ * formatted with `toISOString` to match how that module writes date strings.
  */
 export const savePredictions = async (
   predictions: { date: string; confidence: number }[],
+  predictionMadeDate: Date,
 ) => {
-  const predictionMadeDate = new Date().toISOString().split("T")[0];
+  const madeOn = predictionMadeDate.toISOString().split("T")[0];
 
-  const values = predictions.map((pred) => ({
-    prediction_made_date: predictionMadeDate,
-    predicted_date: pred.date,
-    confidence: pred.confidence,
-    actual_had_flow: null,
-    checked_date: null,
-  }));
+  const existing = await db
+    .select()
+    .from(predictionSnapshots)
+    .where(eq(predictionSnapshots.prediction_made_date, madeOn));
 
-  await db.insert(predictionSnapshots).values(values);
+  const forecast = new Map(predictions.map((p) => [p.date, p.confidence]));
+
+  // Newest row per predicted date is the one kept. Older ones are duplicates
+  // left by the unconditional insert this function replaces.
+  const kept = new Map<string, (typeof existing)[number]>();
+  const superseded: typeof existing = [];
+  for (const row of existing) {
+    const held = kept.get(row.predicted_date);
+    if (!held) {
+      kept.set(row.predicted_date, row);
+    } else if (row.id > held.id) {
+      kept.set(row.predicted_date, row);
+      superseded.push(held);
+    } else {
+      superseded.push(row);
+    }
+  }
+
+  for (const [predictedDate, confidence] of forecast) {
+    const row = kept.get(predictedDate);
+
+    if (!row) {
+      await db.insert(predictionSnapshots).values({
+        prediction_made_date: madeOn,
+        predicted_date: predictedDate,
+        confidence,
+        actual_had_flow: null,
+        checked_date: null,
+      });
+    } else if (row.confidence !== confidence) {
+      await db
+        .update(predictionSnapshots)
+        .set({ confidence })
+        .where(eq(predictionSnapshots.id, row.id));
+    }
+  }
+
+  const retracted = [...kept.values()].filter(
+    (row) => !forecast.has(row.predicted_date),
+  );
+
+  for (const row of [...superseded, ...retracted]) {
+    if (row.actual_had_flow !== null) continue;
+    await db
+      .delete(predictionSnapshots)
+      .where(eq(predictionSnapshots.id, row.id));
+  }
 };
 
 /**

--- a/hooks/useFetchCycleData.ts
+++ b/hooks/useFetchCycleData.ts
@@ -43,7 +43,7 @@ export function useFetchCycleData(
 
       if (predictedDates.length > 0) {
         try {
-          await savePredictions(predictedDates);
+          await savePredictions(predictedDates, localDate);
           await NotificationService.scheduleAllPredictionNotifications(
             predictedDates,
           );


### PR DESCRIPTION
Closes #179.

**Stacked.** Merge order is #191 (docs) → #193 (`expo-file-system`) → #194 (test seam) → this. I do not have merge permission, so the branches are chained rather than rebased; the diff here shows its ancestors until they land.

## The defect

`savePredictions` inserted unconditionally with no dedupe. It is reached from an effect keyed on `date` (`hooks/useMarkedDates.ts:365-368`), and `calendar.tsx:151-153` changes `date` on every day press. So tapping around the calendar with predictions displayed re-inserted the entire prediction set each time — and those rows are what the accuracy percentage is computed from. The number the app shows drifted with how much the user tapped.

The test that names it:

```
✓ survives the calendar tapping that caused the defect
✓ keeps the accuracy metric from being skewed by repeated saves
```

The second one taps ten times, then measures two outcomes, and asserts the metric reads 1 of 2 rather than 10 of 20.

## Two rules beyond the literal minimum

The issue says "reconcile on `(prediction_made_date, predicted_date)`". Reconcile leaves two questions the issue does not answer, and I took a position on both rather than guessing silently:

- **A same-day prediction that is no longer forecast is retracted.** If you log flow at noon and the forecast shifts, the morning's now-withdrawn dates would otherwise sit in the table as predictions that were made, and be scored later. Upsert-only fixes the tapping defect but leaves this smaller version of the same skew.
- **A prediction whose outcome has already been measured is never retracted, and its outcome is never rewritten.** Only its confidence updates. Rewriting a measured outcome would change what the metric is measuring, which is the thing `CONTEXT.md` says the table exists to prevent.

Both are recorded in `CONTEXT.md` under Prediction Snapshot.

Duplicates already accumulated on a user's device collapse on the next save, newest row kept. That is belt-and-braces with the dedupe migration in #187, and it means the idempotence promise holds on a dirty table rather than only a clean one.

## Time is a parameter

`prediction_made_date` came from `new Date().toISOString()`. It is now a parameter, per the plan's rule, and the one caller already had the right value to hand.

This also closes a latent timezone gap. The stamp was formatted in **UTC** while the predictions themselves are generated from a **local**-adjusted reference date (`useFetchCycleData.ts:34-36`). A user west of UTC predicting in the evening stamped the set with tomorrow's date, which put the "same day" reconcile on the wrong day.

`checkPredictionAccuracy` still reads the clock for `checked_date`. Parameterising it ripples into `db/operations/days.ts` and its callers, which is #182's territory; left deliberately.

## No `ON CONFLICT`

There is no unique index on `(prediction_made_date, predicted_date)` yet, so the reconcile is an explicit read-then-write. The index cannot be added before a migration dedupes existing devices — that ordering is exactly what #187 carries.

## Verification

```
$ npx eslint . --max-warnings=0
ESLINT EXIT: 0

$ npm run typecheck
TSC EXIT: 0

$ npm test -- --ci
PASS db/__tests__/predictionSnapshots.test.ts
  savePredictions
    ✓ stores one row per predicted date
    ✓ is idempotent: saving the same set twice changes nothing
    ✓ survives the calendar tapping that caused the defect
    ✓ updates confidence in place when the same day predicts again
    ✓ writes a new generation on a new day, preserving the time series
    ✓ takes the prediction-made date from its caller, not the clock
    ✓ retracts same-day predictions that are no longer forecast
    ✓ never retracts a prediction whose outcome has already been measured
    ✓ leaves a measured outcome alone when confidence is updated
    ✓ keeps the accuracy metric from being skewed by repeated saves
    ✓ does nothing when given no predictions

Test Suites: 5 passed, 5 total
Tests:       77 passed, 77 total
JEST EXIT: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)