### PR TITLE
fix: stop "Saved!" naming a section the user did not touch (#180)

### DIFF
--- a/components/dayView/DayView.tsx
+++ b/components/dayView/DayView.tsx
@@ -22,6 +22,7 @@ import MoodsAccordion from "./MoodsAccordion";
 import NotesAccordion from "./NotesAccordion";
 import IntercourseAccordion from "./IntercourseAccordion";
 import Snackbar from "@/components/ui/Snackbar";
+import { savedSectionLabel } from "@/components/dayView/saveMessage";
 import { useSyncEntries } from "@/hooks/useSyncEntries";
 import { useFetchEntries } from "@/hooks/useFetchEntries";
 import { useFetchMedicationEntries } from "@/hooks/useFetchMedicationEntries";
@@ -167,55 +168,29 @@ export default function DayView() {
     isSavingRef.current = true;
 
     // Compute what changed before the async save so the message can show immediately
-    let savedContent = "";
-    switch (state) {
-      case "flow":
-        if (flow_intensity !== 0) savedContent = "Flow";
-        break;
-      case "symptom":
-        if (selectedSymptoms.length > 0) savedContent = "Symptoms";
-        break;
-      case "mood":
-        if (selectedMoods.length > 0) savedContent = "Moods";
-        break;
-      case "medication":
-        if (selectedMedications.length > 0) savedContent = "Medications";
-        break;
-      case "birthControl":
-        if (selectedBirthControl) savedContent = "Birth Control";
-        break;
-      case "note":
-        if (notes && notes.trim() !== "") savedContent = "Notes";
-        break;
-      case "intercourse":
-        savedContent = "Intercourse";
-        break;
-      default:
-        if (lastSavedData) {
-          if (flow_intensity !== lastSavedData.flow) savedContent = "Flow";
-          else if (notes !== lastSavedData.notes) savedContent = "Notes";
-          else if (
-            JSON.stringify(selectedSymptoms) !==
-            JSON.stringify(lastSavedData.symptoms)
-          )
-            savedContent = "Symptoms";
-          else if (
-            JSON.stringify(selectedMoods) !==
-            JSON.stringify(lastSavedData.moods)
-          )
-            savedContent = "Moods";
-          else if (
-            JSON.stringify(selectedMedications) !==
-            JSON.stringify(lastSavedData.medications)
-          )
-            savedContent = "Medications";
-          else if (selectedBirthControl !== lastSavedData.birthControl)
-            savedContent = "Birth Control";
-          else if (intercourse !== lastSavedData.intercourse)
-            savedContent = "Intercourse";
-        }
-        break;
-    }
+    const savedContent = savedSectionLabel(
+      state,
+      {
+        flow: flow_intensity,
+        notes,
+        symptoms: selectedSymptoms,
+        moods: selectedMoods,
+        medications: selectedMedications,
+        birthControl: selectedBirthControl,
+        intercourse,
+      },
+      lastSavedData
+        ? {
+            flow: lastSavedData.flow,
+            notes: lastSavedData.notes,
+            symptoms: lastSavedData.symptoms,
+            moods: lastSavedData.moods,
+            medications: lastSavedData.medications,
+            birthControl: lastSavedData.birthControl,
+            intercourse: lastSavedData.intercourse,
+          }
+        : null,
+    );
 
     // Optimistically show the save message before the DB write completes
     if (savedContent) {

--- a/components/dayView/__tests__/saveMessage.test.ts
+++ b/components/dayView/__tests__/saveMessage.test.ts
@@ -1,0 +1,123 @@
+import {
+  savedSectionLabel,
+  type LoggedDaySnapshot,
+} from "@/components/dayView/saveMessage";
+
+/**
+ * The exact strings the accordions pass to `setExpandedAccordion`. Kept here
+ * as literals on purpose: this test's job is to prove the save-message logic
+ * agrees with what the accordions actually send, so reading them from a shared
+ * constant would assume the very thing under test. #184 replaces both sides
+ * with one enumeration, at which point this list becomes that enumeration.
+ */
+const SECTION_FROM_ACCORDION = {
+  flow: "flow", // FlowAccordion.tsx:188
+  symptoms: "symptoms", // SymptomsAccordion.tsx:53
+  moods: "mood", // MoodsAccordion.tsx:52
+  medications: "medications", // MedicationsAccordion.tsx:61
+  birthControl: "birthControl", // BirthControlAccordion.tsx:227
+  intercourse: "intercourse", // IntercourseAccordion.tsx:29
+  notes: "notes", // NotesAccordion.tsx:24
+};
+
+const empty: LoggedDaySnapshot = {
+  flow: 0,
+  notes: "",
+  symptoms: [],
+  moods: [],
+  medications: [],
+  birthControl: null,
+  intercourse: false,
+};
+
+const filled: LoggedDaySnapshot = {
+  flow: 3,
+  notes: "slept badly",
+  symptoms: ["Cramps"],
+  moods: ["Calm"],
+  medications: ["Ibuprofen"],
+  birthControl: "Pill",
+  intercourse: true,
+};
+
+describe("savedSectionLabel, with a section expanded", () => {
+  it.each([
+    [SECTION_FROM_ACCORDION.flow, "Flow"],
+    [SECTION_FROM_ACCORDION.symptoms, "Symptoms"],
+    [SECTION_FROM_ACCORDION.moods, "Moods"],
+    [SECTION_FROM_ACCORDION.medications, "Medications"],
+    [SECTION_FROM_ACCORDION.birthControl, "Birth Control"],
+    [SECTION_FROM_ACCORDION.intercourse, "Intercourse"],
+    [SECTION_FROM_ACCORDION.notes, "Notes"],
+  ])("names %s as %s", (section, label) => {
+    expect(savedSectionLabel(section, filled, null)).toBe(label);
+  });
+
+  it.each([
+    [SECTION_FROM_ACCORDION.flow],
+    [SECTION_FROM_ACCORDION.symptoms],
+    [SECTION_FROM_ACCORDION.moods],
+    [SECTION_FROM_ACCORDION.medications],
+    [SECTION_FROM_ACCORDION.birthControl],
+    [SECTION_FROM_ACCORDION.notes],
+  ])("says nothing for %s when that section is empty", (section) => {
+    expect(savedSectionLabel(section, empty, null)).toBeNull();
+  });
+
+  it("reports intercourse even when it is being turned off", () => {
+    // Unlike the others, absence is itself a value the user chose.
+    expect(
+      savedSectionLabel(SECTION_FROM_ACCORDION.intercourse, empty, null),
+    ).toBe("Intercourse");
+  });
+
+  it("never attributes a save to a section other than the expanded one", () => {
+    // The defect: "symptoms" was a dead case, so this fell through to the
+    // fixed-priority fallback and announced "Flow Saved!" while the user was
+    // editing symptoms.
+    const lastSaved: LoggedDaySnapshot = { ...filled, flow: 1, symptoms: [] };
+
+    expect(
+      savedSectionLabel(SECTION_FROM_ACCORDION.symptoms, filled, lastSaved),
+    ).toBe("Symptoms");
+  });
+});
+
+describe("savedSectionLabel, with no section expanded", () => {
+  it("falls back to whatever differs from the last save", () => {
+    expect(
+      savedSectionLabel(null, filled, { ...filled, moods: ["Anxious"] }),
+    ).toBe("Moods");
+  });
+
+  it("says nothing when there is no last save to compare against", () => {
+    expect(savedSectionLabel(null, filled, null)).toBeNull();
+  });
+
+  it("treats an unset note as empty rather than as a change", () => {
+    expect(
+      savedSectionLabel(
+        SECTION_FROM_ACCORDION.notes,
+        {
+          ...filled,
+          notes: undefined,
+        },
+        null,
+      ),
+    ).toBeNull();
+  });
+
+  it("says nothing when nothing changed", () => {
+    expect(savedSectionLabel(null, filled, filled)).toBeNull();
+  });
+
+  it("keeps its fixed priority order when several things changed", () => {
+    expect(
+      savedSectionLabel(null, filled, {
+        ...filled,
+        flow: 1,
+        notes: "different",
+      }),
+    ).toBe("Flow");
+  });
+});

--- a/components/dayView/saveMessage.ts
+++ b/components/dayView/saveMessage.ts
@@ -1,0 +1,66 @@
+/**
+ * Which Section a save should be attributed to, as a label for the
+ * "<Section> Saved!" message.
+ *
+ * Extracted from the switch inside DayView's onSave so that the agreement
+ * between what the accordions send and what this reads is testable. It was not
+ * testable before, and three of the seven cases had never fired: the
+ * accordions send "symptoms", "medications" and "notes" while the switch
+ * matched "symptom", "medication" and "note". Those saves fell through to the
+ * fixed-priority fallback, which can name a Section the user did not touch.
+ *
+ * The section strings are still bare strings here, which is the underlying
+ * weakness. #184 replaces them with a Section enumeration so the disagreement
+ * stops compiling rather than being caught by this test.
+ */
+export type LoggedDaySnapshot = {
+  flow: number;
+  notes: string | undefined;
+  symptoms: string[];
+  moods: string[];
+  medications: string[];
+  birthControl: string | null;
+  intercourse: boolean;
+};
+
+const sameNames = (a: string[], b: string[]) =>
+  JSON.stringify(a) === JSON.stringify(b);
+
+export function savedSectionLabel(
+  expandedSection: string | null,
+  current: LoggedDaySnapshot,
+  lastSaved: LoggedDaySnapshot | null,
+): string | null {
+  switch (expandedSection) {
+    case "flow":
+      return current.flow !== 0 ? "Flow" : null;
+    case "symptoms":
+      return current.symptoms.length > 0 ? "Symptoms" : null;
+    case "mood":
+      return current.moods.length > 0 ? "Moods" : null;
+    case "medications":
+      return current.medications.length > 0 ? "Medications" : null;
+    case "birthControl":
+      return current.birthControl ? "Birth Control" : null;
+    case "notes":
+      return current.notes && current.notes.trim() !== "" ? "Notes" : null;
+    case "intercourse":
+      // Absence is itself a value the user chose here, so unlike the others
+      // there is no "empty" case to stay quiet about.
+      return "Intercourse";
+  }
+
+  if (!lastSaved) return null;
+
+  // No Section expanded, so fall back to whatever differs, in a fixed order.
+  if (current.flow !== lastSaved.flow) return "Flow";
+  if (current.notes !== lastSaved.notes) return "Notes";
+  if (!sameNames(current.symptoms, lastSaved.symptoms)) return "Symptoms";
+  if (!sameNames(current.moods, lastSaved.moods)) return "Moods";
+  if (!sameNames(current.medications, lastSaved.medications))
+    return "Medications";
+  if (current.birthControl !== lastSaved.birthControl) return "Birth Control";
+  if (current.intercourse !== lastSaved.intercourse) return "Intercourse";
+
+  return null;
+}


### PR DESCRIPTION
Closes #180.

**Stacked.** Merge order: #191 → #193 → #194 → #195 → this.

## The defect

| `DayView` matched | accordion sends |
| --- | --- |
| `"symptom"` | `"symptoms"` (`SymptomsAccordion.tsx:53`) |
| `"medication"` | `"medications"` (`MedicationsAccordion.tsx:61`) |
| `"note"` | `"notes"` (`NotesAccordion.tsx:24`) |

Three of seven cases had never fired. Those saves fell through to the `default` branch, whose fixed priority order checks flow first — so editing a symptom on a day whose flow differs from the last save announces **"Flow Saved!"**.

Nothing in either signature reveals the two sides are meant to agree. The shared type is `state: string | null`.

## What I did beyond making the strings agree

The issue calls for the minimal fix, and three edited string literals would have been it. I moved the decision into `components/dayView/saveMessage.ts` as a pure function instead, for one reason: **the strings agreeing is exactly the property that needs a test**, and it was sitting inside a `useCallback` with a 22-item dependency array where nothing could reach it. Changing three literals with no test would leave the next drift just as invisible as this one.

The extracted function is a straight transcription — same cases, same fallback, same priority order. The only behaviour change is the three strings.

The test lists the accordion strings as literals with their source line in a comment, rather than importing a shared constant, because importing one would assume the very thing under test:

```
✓ names flow as Flow
✓ names symptoms as Symptoms
✓ names mood as Moods
✓ names medications as Medications
✓ names birthControl as Birth Control
✓ names intercourse as Intercourse
✓ names notes as Notes
✓ never attributes a save to a section other than the expanded one
```

That last one is the regression test: it sets up the exact state that produced "Flow Saved!" while editing symptoms.

If you would rather see the three-literal version, say so and I will reduce it — but the test goes away with it.

## Two things worth knowing

- **`"mood"` is singular on both sides and always matched.** So the naming is inconsistent even after this fix: six plural, one singular. #184's enumeration is where that gets settled; changing it here would be a behaviour change wearing a defect fix's clothes.
- **The pregnancy day view is not affected.** `PregnancyDayView.tsx:77` shows a bare `"Saved!"` with no section attribution, so it has no switch to disagree with.

## Verification

```
$ npx eslint . --max-warnings=0
ESLINT EXIT: 0

$ npm run typecheck
TSC EXIT: 0

$ npm test -- --ci
Test Suites: 6 passed, 6 total
Tests:       97 passed, 97 total
JEST EXIT: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)