### PR TITLE
refactor: give gestational age a module (#188)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ This file is maintained lazily: terms are added when a design decision actually 
 
 **Tracking Mode**: which of the two experiences the app is presenting, cycle or pregnancy. Durably a setting; expressed at runtime as which route group is mounted.
 
-**Gestational Age**: the derived view of a pregnancy: given a stored start date, an offset and a reference day, it yields the pregnancy day, week, day within the week, trimester, due date and progress. Derived, never stored. The inverse mapping, from each setup answer back to a start date and offset, belongs to the same module.
+**Gestational Age**: the derived view of a pregnancy: given a stored start date, an offset and a reference day, it yields the pregnancy day, week, day within the week, trimester, due date and progress. Derived, never stored. The inverse mapping, from each setup answer back to a start date and offset, belongs to the same module. The week is not capped at 40, because a pregnancy can run past its due date; accessors that need a bounded week, such as baby size and week content, clamp for themselves. Progress and days remaining are bounded, since neither means anything past full term.
 
 ## Terms we avoid
 

--- a/app/(pregnancy-tabs)/index.tsx
+++ b/app/(pregnancy-tabs)/index.tsx
@@ -8,19 +8,11 @@ import PregnancyProgressRing from "@/components/pregnancy/PregnancyProgressRing"
 import PregnancySetupDialog from "@/components/pregnancy/PregnancySetupDialog";
 import { getSetting } from "@/db/database";
 import { SettingsKeys } from "@/constants/Settings";
-import {
-  DAYS_IN_WEEK,
-  FULL_TERM_DAYS,
-  getBabySizeForWeek,
-  getTrimesterLabel,
-  PREGNANCY_WEEKS,
-} from "@/constants/Pregnancy";
+import { getBabySizeForWeek, PREGNANCY_WEEKS } from "@/constants/Pregnancy";
 import { usePregnancySetup } from "@/hooks/usePregnancySetup";
 import {
-  addDays,
-  differenceInDays,
   formatDueDate,
-  parseISODate,
+  gestationalAge,
   startOfLocalDay,
 } from "@/utils/pregnancyDates";
 
@@ -90,54 +82,17 @@ export default function PregnancyHome() {
     loadPregnancySettings();
   }, [loadPregnancySettings]);
 
-  const pregnancyDay = useMemo(() => {
-    if (!startDateIso) return null;
-    const startDate = parseISODate(startDateIso);
-    return Math.max(
-      0,
-      differenceInDays(startDate, today) + gestationOffsetDays,
-    );
-  }, [startDateIso, today, gestationOffsetDays]);
+  // One derivation, from utils/pregnancyDates.ts, rather than seven memos
+  // retyping the rule that also lives in usePregnancySetup and the info route.
+  const age = useMemo(
+    () =>
+      startDateIso
+        ? gestationalAge(startDateIso, gestationOffsetDays, today)
+        : null,
+    [startDateIso, gestationOffsetDays, today],
+  );
 
-  const weekNumber = useMemo(() => {
-    if (pregnancyDay === null) return null;
-    return Math.min(
-      PREGNANCY_WEEKS,
-      Math.floor(pregnancyDay / DAYS_IN_WEEK) + 1,
-    );
-  }, [pregnancyDay]);
-
-  const daysInCurrentWeek = useMemo(() => {
-    if (pregnancyDay === null) return 0;
-    return pregnancyDay % DAYS_IN_WEEK;
-  }, [pregnancyDay]);
-
-  const babySize = useMemo(() => {
-    if (!weekNumber) return "";
-    return getBabySizeForWeek(weekNumber);
-  }, [weekNumber]);
-
-  const dueDaysRemaining = useMemo(() => {
-    if (pregnancyDay === null) return null;
-    return Math.max(0, FULL_TERM_DAYS - pregnancyDay);
-  }, [pregnancyDay]);
-
-  const dueDate = useMemo(() => {
-    if (!startDateIso) return null;
-    const startDate = parseISODate(startDateIso);
-    const effectivePregnancyDayZero = addDays(startDate, -gestationOffsetDays);
-    return addDays(effectivePregnancyDayZero, FULL_TERM_DAYS);
-  }, [startDateIso, gestationOffsetDays]);
-
-  const trimesterLabel = useMemo(() => {
-    if (!weekNumber) return "";
-    return getTrimesterLabel(weekNumber);
-  }, [weekNumber]);
-
-  const ringProgress = useMemo(() => {
-    if (pregnancyDay === null) return 0;
-    return Math.min(1, Math.max(0, pregnancyDay / FULL_TERM_DAYS));
-  }, [pregnancyDay]);
+  const babySize = age ? getBabySizeForWeek(age.weekNumber) : "";
 
   return (
     <FadeInView duration={200} backgroundColor={theme.colors.background}>
@@ -157,28 +112,29 @@ export default function PregnancyHome() {
               <View style={styles.progressSection}>
                 <View style={styles.progressContent}>
                   <PregnancyProgressRing
-                    weekNumber={weekNumber ?? 0}
+                    weekNumber={age?.weekNumber ?? 0}
                     babySize={babySize}
-                    ringProgress={ringProgress}
+                    ringProgress={age?.progress ?? 0}
                   />
 
                   <Text
                     variant="titleMedium"
                     style={{ color: theme.colors.onSurface }}
                   >
-                    Week {weekNumber ?? 0} • Day {daysInCurrentWeek + 1}
+                    Week {age?.weekNumber ?? 0} • Day{" "}
+                    {(age?.dayInWeek ?? 0) + 1}
                   </Text>
                   <Text
                     variant="bodyLarge"
                     style={{ color: theme.colors.onSurfaceVariant }}
                   >
-                    {trimesterLabel}
+                    {age?.trimesterLabel ?? ""}
                   </Text>
                   <Text
                     variant="bodyLarge"
                     style={{ color: theme.colors.onSurfaceVariant }}
                   >
-                    Due Date: {dueDate ? formatDueDate(dueDate) : "-"}
+                    Due Date: {age ? formatDueDate(age.dueDate) : "-"}
                   </Text>
                 </View>
 
@@ -189,8 +145,8 @@ export default function PregnancyHome() {
                     { color: theme.colors.onSurfaceVariant },
                   ]}
                 >
-                  {dueDaysRemaining !== null
-                    ? `${dueDaysRemaining} days until week ${PREGNANCY_WEEKS}.`
+                  {age
+                    ? `${age.dueDaysRemaining} days until week ${PREGNANCY_WEEKS}.`
                     : "Set up your pregnancy details to see progress."}
                 </Text>
 

--- a/app/(pregnancy-tabs)/info.tsx
+++ b/app/(pregnancy-tabs)/info.tsx
@@ -15,12 +15,11 @@ import { IconSymbol } from "@/components/ui/IconSymbol";
 import { getSetting } from "@/db/database";
 import { SettingsKeys } from "@/constants/Settings";
 import {
-  DAYS_IN_WEEK,
-  PREGNANCY_WEEKS,
+  DEFAULT_GESTATION_OFFSET_DAYS,
   getPregnancyWeekContent,
   getTrimesterLabel,
 } from "@/constants/Pregnancy";
-import { differenceInDays, parseISODate } from "@/utils/pregnancyDates";
+import { gestationalAge, startOfLocalDay } from "@/utils/pregnancyDates";
 
 // The idea here is that this tab will eventually be up to date with whatever week the user is at
 // Placeholder is week 5, but by the end of pregnancy tracking implementation, this tab *should* be providing information accurate
@@ -198,25 +197,13 @@ export default function PregnancyInfo() {
       return;
     }
 
-    const todayDate = new Date();
-    const today = new Date(
-      todayDate.getFullYear(),
-      todayDate.getMonth(),
-      todayDate.getDate(),
+    const age = gestationalAge(
+      startSetting.value,
+      Number(offsetSetting?.value ?? DEFAULT_GESTATION_OFFSET_DAYS),
+      startOfLocalDay(),
     );
 
-    const startDate = parseISODate(startSetting.value);
-    const offset = Number(offsetSetting?.value ?? 14);
-
-    const pregnancyDay = Math.max(
-      0,
-      differenceInDays(startDate, today) + offset,
-    );
-
-    const week = Math.min(
-      PREGNANCY_WEEKS,
-      Math.floor(pregnancyDay / DAYS_IN_WEEK) + 1,
-    );
+    const week = age.weekNumber;
 
     setCurrentWeek(week);
   }, []);

--- a/hooks/usePregnancySetup.ts
+++ b/hooks/usePregnancySetup.ts
@@ -8,9 +8,7 @@ import { getSetting, updateSetting } from "@/db/database";
 import { SettingsKeys } from "@/constants/Settings";
 import {
   clampPregnancyValue,
-  CONCEPTION_TO_CURRENT_DAY_OFFSET,
   DAYS_FROM_LMP_TO_DUE,
-  DAYS_IN_WEEK,
   DEFAULT_DAYS_WHEN_UNCONFIGURED,
   DEFAULT_GESTATION_OFFSET_DAYS,
   DEFAULT_LMP_DAYS_AGO,
@@ -31,10 +29,10 @@ import type {
 } from "@/components/pregnancy/pregnancySetupTypes";
 import {
   addDays,
-  differenceInDays,
-  formatAsISODate,
-  parseISODate,
+  anchorFromSetupAnswer,
+  gestationalAge,
   startOfLocalDay,
+  type SetupAnswer,
 } from "@/utils/pregnancyDates";
 
 type UsePregnancySetupOptions = {
@@ -113,15 +111,10 @@ export function usePregnancySetup({
       }
 
       if (startSetting?.value) {
-        const startDate = parseISODate(startSetting.value);
-        const currentPregnancyDay = Math.max(
-          0,
-          differenceInDays(startDate, normalizedToday) + offset,
-        );
-        const derivedWeek = Math.floor(currentPregnancyDay / DAYS_IN_WEEK) + 1;
-        setWeeksInput(String(derivedWeek));
-        setDaysInput(String(currentPregnancyDay % DAYS_IN_WEEK));
-        applyDefaultDateInputs(normalizedToday, true, currentPregnancyDay);
+        const age = gestationalAge(startSetting.value, offset, normalizedToday);
+        setWeeksInput(String(age.weekNumber));
+        setDaysInput(String(age.dayInWeek));
+        applyDefaultDateInputs(normalizedToday, true, age.pregnancyDay);
       } else {
         applyDefaultDateInputs(normalizedToday, false);
       }
@@ -220,83 +213,61 @@ export function usePregnancySetup({
     setSetupError(null);
     setSaving(true);
     try {
-      let targetCurrentPregnancyDay = 0;
-      let anchorStartDate = today;
+      const weeksAndDaysAreValid = () =>
+        !Number.isNaN(parsedWeeks) &&
+        parsedWeeks >= 0 &&
+        parsedWeeks <= MAX_PREGNANCY_WEEK_INPUT &&
+        !Number.isNaN(parsedDays) &&
+        parsedDays >= 0 &&
+        parsedDays <= MAX_DAY_IN_WEEK_INPUT;
 
-      const computeFromDueDate = () => {
-        const daysUntilDue = differenceInDays(today, dueDateInput);
-        return clampPregnancyValue(
-          FULL_TERM_DAYS - daysUntilDue,
-          0,
-          MAX_PREGNANCY_WEEK_INPUT * DAYS_IN_WEEK,
-        );
-      };
+      const weeksAndDaysError = `Please choose a valid week (0-${MAX_PREGNANCY_WEEK_INPUT}) and day (0-${MAX_DAY_IN_WEEK_INPUT}).`;
+
+      // Which question the user answered. The "not sure" paths lead back to
+      // the same four answers rather than repeating their arithmetic.
+      let answer: SetupAnswer;
 
       if (setupMethod === "dueDate") {
-        targetCurrentPregnancyDay = computeFromDueDate();
+        answer = { method: "dueDate", dueDate: dueDateInput };
       } else if (setupMethod === "weeksPregnant") {
-        if (
-          Number.isNaN(parsedWeeks) ||
-          parsedWeeks < 0 ||
-          parsedWeeks > MAX_PREGNANCY_WEEK_INPUT ||
-          Number.isNaN(parsedDays) ||
-          parsedDays < 0 ||
-          parsedDays > MAX_DAY_IN_WEEK_INPUT
-        ) {
-          setSetupError(
-            `Please choose a valid week (0-${MAX_PREGNANCY_WEEK_INPUT}) and day (0-${MAX_DAY_IN_WEEK_INPUT}).`,
-          );
+        if (!weeksAndDaysAreValid()) {
+          setSetupError(weeksAndDaysError);
           return;
         }
-        targetCurrentPregnancyDay =
-          Math.max(0, parsedWeeks - 1) * DAYS_IN_WEEK + parsedDays;
+        answer = {
+          method: "weeksPregnant",
+          weeks: parsedWeeks,
+          days: parsedDays,
+        };
       } else if (setupMethod === "lastPeriod") {
-        anchorStartDate = lastPeriodInput;
-        targetCurrentPregnancyDay = Math.max(
-          0,
-          differenceInDays(lastPeriodInput, today),
-        );
-      } else {
-        if (!notSurePath) {
-          setSetupError("Choose one option so we can estimate your timeline.");
+        answer = { method: "lastPeriod", lastPeriod: lastPeriodInput };
+      } else if (!notSurePath) {
+        setSetupError("Choose one option so we can estimate your timeline.");
+        return;
+      } else if (notSurePath === "doctorDueDate") {
+        answer = { method: "dueDate", dueDate: dueDateInput };
+      } else if (notSurePath === "ultrasoundEstimate") {
+        if (!weeksAndDaysAreValid()) {
+          setSetupError(weeksAndDaysError);
           return;
         }
-        if (notSurePath === "doctorDueDate") {
-          targetCurrentPregnancyDay = computeFromDueDate();
-        } else if (notSurePath === "ultrasoundEstimate") {
-          if (
-            Number.isNaN(parsedWeeks) ||
-            parsedWeeks < 0 ||
-            parsedWeeks > MAX_PREGNANCY_WEEK_INPUT ||
-            Number.isNaN(parsedDays) ||
-            parsedDays < 0 ||
-            parsedDays > MAX_DAY_IN_WEEK_INPUT
-          ) {
-            setSetupError(
-              `Please choose a valid week (0-${MAX_PREGNANCY_WEEK_INPUT}) and day (0-${MAX_DAY_IN_WEEK_INPUT}).`,
-            );
-            return;
-          }
-          targetCurrentPregnancyDay =
-            Math.max(0, parsedWeeks - 1) * DAYS_IN_WEEK + parsedDays;
-        } else if (notSurePath === "lastPeriod") {
-          anchorStartDate = lastPeriodInput;
-          targetCurrentPregnancyDay = Math.max(
-            0,
-            differenceInDays(lastPeriodInput, today),
-          );
-        } else {
-          targetCurrentPregnancyDay = Math.max(
-            0,
-            differenceInDays(conceptionDateInput, today) +
-              CONCEPTION_TO_CURRENT_DAY_OFFSET,
-          );
-        }
+        answer = {
+          method: "weeksPregnant",
+          weeks: parsedWeeks,
+          days: parsedDays,
+        };
+      } else if (notSurePath === "lastPeriod") {
+        answer = { method: "lastPeriod", lastPeriod: lastPeriodInput };
+      } else {
+        answer = {
+          method: "conceptionDate",
+          conceptionDate: conceptionDateInput,
+        };
       }
 
-      const daysSinceStart = differenceInDays(anchorStartDate, today);
-      const offsetDays = targetCurrentPregnancyDay - daysSinceStart;
-      const isoDate = formatAsISODate(anchorStartDate);
+      const { startDateIso: isoDate, gestationOffsetDays: offsetDays } =
+        anchorFromSetupAnswer(answer, today);
+
       await Promise.all([
         updateSetting(SettingsKeys.pregnancyStartDate, isoDate),
         updateSetting(

--- a/utils/__tests__/pregnancyDates.test.ts
+++ b/utils/__tests__/pregnancyDates.test.ts
@@ -1,0 +1,243 @@
+import {
+  DAYS_IN_WEEK,
+  FULL_TERM_DAYS,
+  CONCEPTION_TO_CURRENT_DAY_OFFSET,
+} from "@/constants/Pregnancy";
+import {
+  anchorFromSetupAnswer,
+  differenceInDays,
+  formatAsISODate,
+  gestationalAge,
+  type SetupAnswer,
+} from "@/utils/pregnancyDates";
+
+const day = (iso: string) => {
+  const [year, month, date] = iso.split("-").map(Number);
+  return new Date(year, month - 1, date);
+};
+
+describe("differenceInDays", () => {
+  it("counts calendar days", () => {
+    expect(differenceInDays(day("2026-03-01"), day("2026-03-08"))).toBe(7);
+  });
+
+  it("is not thrown off by a daylight saving transition", () => {
+    // Raw millisecond division floors this to 83 in any timezone that springs
+    // forward in March, which is most of the ones users are in.
+    expect(differenceInDays(day("2026-03-01"), day("2026-05-24"))).toBe(84);
+    expect(differenceInDays(day("2026-11-01"), day("2026-11-30"))).toBe(29);
+  });
+
+  it("goes negative in the other direction", () => {
+    expect(differenceInDays(day("2026-03-08"), day("2026-03-01"))).toBe(-7);
+  });
+});
+
+describe("gestationalAge", () => {
+  it("counts the pregnancy day from the start date plus the offset", () => {
+    const age = gestationalAge("2026-01-01", 14, day("2026-01-08"));
+
+    expect(age.pregnancyDay).toBe(21);
+  });
+
+  it("never reports a negative pregnancy day", () => {
+    const age = gestationalAge("2026-06-01", 0, day("2026-01-01"));
+
+    expect(age.pregnancyDay).toBe(0);
+  });
+
+  it("puts day 0 in week 1", () => {
+    const age = gestationalAge("2026-01-01", 0, day("2026-01-01"));
+
+    expect(age.weekNumber).toBe(1);
+    expect(age.dayInWeek).toBe(0);
+  });
+
+  it("rolls into the next week on the seventh day", () => {
+    expect(gestationalAge("2026-01-01", 6, day("2026-01-01")).weekNumber).toBe(
+      1,
+    );
+    expect(gestationalAge("2026-01-01", 6, day("2026-01-01")).dayInWeek).toBe(
+      6,
+    );
+    expect(gestationalAge("2026-01-01", 7, day("2026-01-01")).weekNumber).toBe(
+      2,
+    );
+    expect(gestationalAge("2026-01-01", 7, day("2026-01-01")).dayInWeek).toBe(
+      0,
+    );
+  });
+
+  it("reports weeks past 40 rather than capping", () => {
+    // A pregnancy can run past its due date. Capping the week here is what
+    // made the clamp in getPregnancyWeekContent unreachable.
+    const age = gestationalAge(
+      "2026-01-01",
+      FULL_TERM_DAYS + 7,
+      day("2026-01-01"),
+    );
+
+    expect(age.weekNumber).toBe(42);
+  });
+
+  it("labels trimesters using the constants accessor", () => {
+    expect(
+      gestationalAge("2026-01-01", 0, day("2026-01-01")).trimesterLabel,
+    ).toBe("1st Trimester");
+    expect(
+      gestationalAge("2026-01-01", 14 * DAYS_IN_WEEK, day("2026-01-01"))
+        .trimesterLabel,
+    ).toBe("2nd Trimester");
+    expect(
+      gestationalAge("2026-01-01", 28 * DAYS_IN_WEEK, day("2026-01-01"))
+        .trimesterLabel,
+    ).toBe("3rd Trimester");
+  });
+
+  it("puts the due date a full term after pregnancy day zero", () => {
+    const age = gestationalAge("2026-01-01", 0, day("2026-01-01"));
+
+    expect(formatAsISODate(age.dueDate)).toBe(
+      formatAsISODate(new Date(2026, 0, 1 + FULL_TERM_DAYS)),
+    );
+  });
+
+  it("moves the due date earlier as the offset grows", () => {
+    const withoutOffset = gestationalAge("2026-01-01", 0, day("2026-01-01"));
+    const withOffset = gestationalAge("2026-01-01", 14, day("2026-01-01"));
+
+    expect(withOffset.dueDate.getTime()).toBeLessThan(
+      withoutOffset.dueDate.getTime(),
+    );
+  });
+
+  it("counts down the days remaining, stopping at zero", () => {
+    expect(
+      gestationalAge("2026-01-01", 0, day("2026-01-01")).dueDaysRemaining,
+    ).toBe(FULL_TERM_DAYS);
+    expect(
+      gestationalAge("2026-01-01", FULL_TERM_DAYS + 30, day("2026-01-01"))
+        .dueDaysRemaining,
+    ).toBe(0);
+  });
+
+  it("reports progress as a fraction, never past one", () => {
+    expect(gestationalAge("2026-01-01", 0, day("2026-01-01")).progress).toBe(0);
+    expect(
+      gestationalAge("2026-01-01", FULL_TERM_DAYS / 2, day("2026-01-01"))
+        .progress,
+    ).toBeCloseTo(0.5);
+    expect(
+      gestationalAge("2026-01-01", FULL_TERM_DAYS + 50, day("2026-01-01"))
+        .progress,
+    ).toBe(1);
+  });
+
+  it("does not read the clock", () => {
+    const fixed = gestationalAge("2026-01-01", 14, day("2026-03-01"));
+
+    expect(gestationalAge("2026-01-01", 14, day("2026-03-01"))).toEqual(fixed);
+  });
+});
+
+describe("anchorFromSetupAnswer", () => {
+  const today = day("2026-03-01");
+
+  const answers: [string, SetupAnswer, number][] = [
+    // [name, answer, the pregnancy day the user is describing]
+    [
+      "a due date twelve weeks out",
+      { method: "dueDate", dueDate: day("2026-05-24") },
+      FULL_TERM_DAYS - 84,
+    ],
+    [
+      "ten weeks and three days",
+      { method: "weeksPregnant", weeks: 10, days: 3 },
+      9 * DAYS_IN_WEEK + 3,
+    ],
+    ["week one, day zero", { method: "weeksPregnant", weeks: 1, days: 0 }, 0],
+    [
+      "a last period fifty days ago",
+      { method: "lastPeriod", lastPeriod: day("2026-01-10") },
+      50,
+    ],
+    [
+      "a conception date thirty days ago",
+      { method: "conceptionDate", conceptionDate: day("2026-01-30") },
+      30 + CONCEPTION_TO_CURRENT_DAY_OFFSET,
+    ],
+  ];
+
+  it.each(answers)(
+    "round-trips %s back to the same pregnancy day",
+    (_name, answer, expectedPregnancyDay) => {
+      const anchor = anchorFromSetupAnswer(answer, today);
+
+      const age = gestationalAge(
+        anchor.startDateIso,
+        anchor.gestationOffsetDays,
+        today,
+      );
+
+      expect(age.pregnancyDay).toBe(expectedPregnancyDay);
+    },
+  );
+
+  it("anchors a last-period answer on the period itself, needing no offset", () => {
+    const anchor = anchorFromSetupAnswer(
+      { method: "lastPeriod", lastPeriod: day("2026-01-10") },
+      today,
+    );
+
+    expect(anchor.startDateIso).toBe("2026-01-10");
+    expect(anchor.gestationOffsetDays).toBe(0);
+  });
+
+  it("anchors the other answers on today", () => {
+    expect(
+      anchorFromSetupAnswer(
+        { method: "weeksPregnant", weeks: 8, days: 0 },
+        today,
+      ).startDateIso,
+    ).toBe("2026-03-01");
+  });
+
+  it("treats week zero as day zero rather than a negative day", () => {
+    const anchor = anchorFromSetupAnswer(
+      { method: "weeksPregnant", weeks: 0, days: 0 },
+      today,
+    );
+
+    expect(
+      gestationalAge(anchor.startDateIso, anchor.gestationOffsetDays, today)
+        .pregnancyDay,
+    ).toBe(0);
+  });
+
+  it("clamps a due date already in the past", () => {
+    const anchor = anchorFromSetupAnswer(
+      { method: "dueDate", dueDate: day("2025-01-01") },
+      today,
+    );
+
+    const age = gestationalAge(
+      anchor.startDateIso,
+      anchor.gestationOffsetDays,
+      today,
+    );
+
+    expect(age.pregnancyDay).toBeLessThanOrEqual(42 * DAYS_IN_WEEK);
+  });
+
+  it("clamps a due date further out than a whole pregnancy", () => {
+    const anchor = anchorFromSetupAnswer(
+      { method: "dueDate", dueDate: day("2027-06-01") },
+      today,
+    );
+
+    expect(
+      gestationalAge(anchor.startDateIso, anchor.gestationOffsetDays, today)
+        .pregnancyDay,
+    ).toBe(0);
+  });
+});

--- a/utils/pregnancyDates.ts
+++ b/utils/pregnancyDates.ts
@@ -1,3 +1,12 @@
+import {
+  CONCEPTION_TO_CURRENT_DAY_OFFSET,
+  DAYS_IN_WEEK,
+  FULL_TERM_DAYS,
+  MAX_PREGNANCY_WEEK_INPUT,
+  clampPregnancyValue,
+  getTrimesterLabel,
+} from "@/constants/Pregnancy";
+
 export const formatAsISODate = (date: Date): string => {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
@@ -10,8 +19,28 @@ export const parseISODate = (value: string): Date => {
   return new Date(year, month - 1, day);
 };
 
-export const differenceInDays = (startDate: Date, endDate: Date): number =>
-  Math.floor((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24));
+/**
+ * Whole calendar days between two local dates.
+ *
+ * Both dates are rebuilt through `Date.UTC` from their calendar components
+ * first. Dividing raw millisecond deltas is off by one across a daylight
+ * saving transition: a span of 84 calendar days that crosses spring-forward is
+ * 84 days minus an hour, and flooring that gives 83. This is the same
+ * treatment services/cyclePredictionLogic.ts:31 already uses.
+ */
+export const differenceInDays = (startDate: Date, endDate: Date): number => {
+  const start = Date.UTC(
+    startDate.getFullYear(),
+    startDate.getMonth(),
+    startDate.getDate(),
+  );
+  const end = Date.UTC(
+    endDate.getFullYear(),
+    endDate.getMonth(),
+    endDate.getDate(),
+  );
+  return Math.round((end - start) / (1000 * 60 * 60 * 24));
+};
 
 export const addDays = (base: Date, days: number): Date => {
   const next = new Date(base);
@@ -24,3 +53,127 @@ export const formatDueDate = (date: Date): string =>
 
 export const startOfLocalDay = (date: Date = new Date()): Date =>
   new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+/**
+ * The derived view of a pregnancy. Nothing here is stored; it is all a
+ * function of the stored start date, the stored offset and which day you ask
+ * about. See CONTEXT.md, Gestational Age.
+ */
+export type GestationalAge = {
+  /** Days elapsed, where the first day of the pregnancy is day 0. */
+  pregnancyDay: number;
+  /** One-based, and deliberately not capped at 40. */
+  weekNumber: number;
+  /** 0 to 6 within `weekNumber`. */
+  dayInWeek: number;
+  trimesterLabel: string;
+  dueDate: Date;
+  /** Never negative; a pregnancy past its due date reads 0. */
+  dueDaysRemaining: number;
+  /** 0 to 1, for progress indicators. */
+  progress: number;
+};
+
+/**
+ * Resolves a stored start date and offset against a reference day.
+ *
+ * `referenceDay` is required rather than defaulting to `new Date()`. A default
+ * that reads the clock is a hidden input, and it is why this rule was retyped
+ * at three screens instead of tested once.
+ *
+ * The week is not capped at 40. A pregnancy can run past its due date, and the
+ * accessors that need a bounded week clamp for themselves.
+ */
+export function gestationalAge(
+  startDateIso: string,
+  gestationOffsetDays: number,
+  referenceDay: Date,
+): GestationalAge {
+  const startDate = parseISODate(startDateIso);
+  const pregnancyDay = Math.max(
+    0,
+    differenceInDays(startDate, referenceDay) + gestationOffsetDays,
+  );
+
+  const pregnancyDayZero = addDays(startDate, -gestationOffsetDays);
+
+  return {
+    pregnancyDay,
+    weekNumber: Math.floor(pregnancyDay / DAYS_IN_WEEK) + 1,
+    dayInWeek: pregnancyDay % DAYS_IN_WEEK,
+    trimesterLabel: getTrimesterLabel(
+      Math.floor(pregnancyDay / DAYS_IN_WEEK) + 1,
+    ),
+    dueDate: addDays(pregnancyDayZero, FULL_TERM_DAYS),
+    dueDaysRemaining: Math.max(0, FULL_TERM_DAYS - pregnancyDay),
+    progress: Math.min(1, Math.max(0, pregnancyDay / FULL_TERM_DAYS)),
+  };
+}
+
+/** What the user told us during setup, in the terms they were asked. */
+export type SetupAnswer =
+  | { method: "dueDate"; dueDate: Date }
+  | { method: "weeksPregnant"; weeks: number; days: number }
+  | { method: "lastPeriod"; lastPeriod: Date }
+  | { method: "conceptionDate"; conceptionDate: Date };
+
+/** What gets stored: everything else is derived from these two. */
+export type PregnancyAnchor = {
+  startDateIso: string;
+  gestationOffsetDays: number;
+};
+
+/**
+ * The inverse of `gestationalAge`: turns a setup answer into the start date
+ * and offset to store.
+ *
+ * Each branch works out which pregnancy day the user is describing, then the
+ * shared tail below converts that into an offset from whichever date is being
+ * anchored on. A last-period answer anchors on the period itself, so its
+ * offset comes out as 0; the others anchor on today.
+ */
+export function anchorFromSetupAnswer(
+  answer: SetupAnswer,
+  today: Date,
+): PregnancyAnchor {
+  let anchorDate = today;
+  let pregnancyDayToday: number;
+
+  switch (answer.method) {
+    case "dueDate":
+      pregnancyDayToday = clampPregnancyValue(
+        FULL_TERM_DAYS - differenceInDays(today, answer.dueDate),
+        0,
+        MAX_PREGNANCY_WEEK_INPUT * DAYS_IN_WEEK,
+      );
+      break;
+
+    case "weeksPregnant":
+      pregnancyDayToday =
+        Math.max(0, answer.weeks - 1) * DAYS_IN_WEEK + answer.days;
+      break;
+
+    case "lastPeriod":
+      anchorDate = answer.lastPeriod;
+      pregnancyDayToday = Math.max(
+        0,
+        differenceInDays(answer.lastPeriod, today),
+      );
+      break;
+
+    case "conceptionDate":
+      pregnancyDayToday = Math.max(
+        0,
+        differenceInDays(answer.conceptionDate, today) +
+          CONCEPTION_TO_CURRENT_DAY_OFFSET,
+      );
+      break;
+  }
+
+  const daysSinceAnchor = differenceInDays(anchorDate, today);
+
+  return {
+    startDateIso: formatAsISODate(anchorDate),
+    gestationOffsetDays: pregnancyDayToday - daysSinceAnchor,
+  };
+}


### PR DESCRIPTION
Closes #188. Completes track C.

**Stacked.** Merge order: #191 → #193 → #194 → #195 → #196 → #197 → #198 → this.

## What was retyped three times

| Site | What it derived |
| --- | --- |
| `app/(pregnancy-tabs)/index.tsx:93-141` | pregnancy day, week, day in week, due date, days remaining, trimester, ring progress — seven `useMemo`s |
| `hooks/usePregnancySetup.ts:117-122` | pregnancy day and week again, identically |
| `app/(pregnancy-tabs)/info.tsx` | a third time, with a hardcoded `?? 14` instead of `DEFAULT_GESTATION_OFFSET_DAYS` |

All three now call `gestationalAge(startDateIso, offsetDays, referenceDay)`. The reference day is a required parameter, per the plan's rule — a default that reads the clock is a hidden input, and it is exactly why this rule was retyped instead of tested.

## The inverse mapping

`anchorFromSetupAnswer(answer, today)` returns the `{ startDateIso, gestationOffsetDays }` to store. It came out of a `useCallback` that also validated input, set error strings and wrote settings; validation and persistence stay in the hook, only the arithmetic moved. The two "not sure" paths that duplicated the due-date and weeks-pregnant arithmetic now map onto the same two answers rather than repeating them.

The test that makes this worth doing is a round trip — answer in, `gestationalAge` out, same pregnancy day:

```
✓ round-trips a due date twelve weeks out back to the same pregnancy day
✓ round-trips ten weeks and three days back to the same pregnancy day
✓ round-trips week one, day zero back to the same pregnancy day
✓ round-trips a last period fifty days ago back to the same pregnancy day
✓ round-trips a conception date thirty days ago back to the same pregnancy day
```

24 tests total, none of which need a date picker or a database.

## Two behaviour changes, both deliberate

**1. The week is no longer capped at 40.** All three copies did `Math.min(PREGNANCY_WEEKS, …)`. A pregnancy can run past its due date, and capping here is what made the clamp added in #198 unreachable. Progress and days remaining stay bounded, since neither means anything past full term. Recorded in `CONTEXT.md`.

**2. `differenceInDays` was off by one across daylight saving.** This one I did not go looking for; the round-trip test failed by a day and the reason was:

```
Expected: 196
Received: 197
```

It divided raw millisecond deltas, so a span of 84 calendar days crossing spring-forward is 84 days minus an hour, which floors to 83. A due date twelve weeks out was computed as eleven weeks and six days. `services/cyclePredictionLogic.ts:31` already does this correctly, via `Date.UTC` on the calendar components — the correct version was in the repo, in the module that had tests. This one takes the same treatment.

**CI runs in UTC and would never have caught it.** The suite is verified under both:

```
$ TZ=America/Los_Angeles npm test -- --ci
Test Suites: 10 passed, 10 total
Tests:       137 passed, 137 total
JEST EXIT (LA): 0

$ TZ=UTC npm test -- --ci
Tests:       137 passed, 137 total
JEST EXIT (UTC): 0
```

If you would rather the DST fix shipped on its own, it is a self-contained hunk in `utils/pregnancyDates.ts` plus three tests and I can split it out.

## Verification

```
$ npx eslint . --max-warnings=0
ESLINT EXIT: 0

$ npm run typecheck
TSC EXIT: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)