### PR TITLE
refactor: give "a cycle" one definition (#186)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -16,7 +16,7 @@ This file is maintained lazily: terms are added when a design decision actually 
 
 **Entry**: a single recorded selection joining a Day to a Catalogue item: `mood_entries`, `symptom_entries`, `medication_entries`. An Entry may carry its own detail, such as a Medication's `time_taken`.
 
-**Cycle**: a run of consecutive Days with flow, bounded either by the `is_cycle_start` / `is_cycle_end` markers the user sets or by gaps between logged flow. There is exactly one definition of how flow groups into Cycles, and it lives in `services/cyclePredictionLogic.ts`.
+**Cycle**: a run of consecutive Days with flow, bounded either by the `is_cycle_start` / `is_cycle_end` markers the user sets or by gaps between logged flow. There is exactly one definition of how flow groups into Cycles, and it lives in `services/cyclePredictionLogic.ts`. Days with no flow are not part of a Cycle and do not bridge two of them. A Cycle counts towards prediction only once it reaches `MIN_CONSECUTIVE_DAYS`, and that same count is what gates predictions everywhere they are gated.
 
 **Prediction**: a forecast of a future Day with flow, carrying a confidence. Predictions are derived, never authored.
 

--- a/__tests__/cyclePredictionLogic.test.ts
+++ b/__tests__/cyclePredictionLogic.test.ts
@@ -148,8 +148,9 @@ describe("calculateConfidence", () => {
     },
   ];
   it("returns 30 when cycleLengths.length < 2", () => {
-    expect(calculateConfidence(twoCycles, [])).toBe(30);
-    expect(calculateConfidence(twoCycles, [28])).toBe(30);
+    const referenceDate = new Date("2025-02-01");
+    expect(calculateConfidence(twoCycles, [], referenceDate)).toBe(30);
+    expect(calculateConfidence(twoCycles, [28], referenceDate)).toBe(30);
   });
   it("returns value in 0-100 when cycleLengths.length >= 2", () => {
     const c = calculateConfidence(twoCycles, [28, 28], new Date("2025-02-01"));

--- a/__tests__/cycleState.test.ts
+++ b/__tests__/cycleState.test.ts
@@ -1,0 +1,246 @@
+/**
+ * The one definition of a Cycle.
+ *
+ * Before this, three modules answered "how many cycles have I logged?"
+ * differently: the tested grouping here, a private copy in useCyclePhase, and
+ * a different gap-detection algorithm in the settings screen. These tests pin
+ * the answers all three now share, including the inputs where they used to
+ * disagree.
+ */
+import {
+  countCompleteCycles,
+  currentCycleState,
+  cycleStats,
+  determinePhase,
+  groupFlowIntoCycles,
+  calculateCycleVariation,
+} from "@/services/cyclePredictionLogic";
+import { CYCLE_PREDICTION_CONSTANTS } from "@/constants/CyclePrediction";
+import type { DayData } from "@/constants/Interfaces";
+
+function day(
+  id: number,
+  date: string,
+  flow: number,
+  opts?: { is_cycle_start?: boolean; is_cycle_end?: boolean },
+): DayData {
+  return { id, date, flow_intensity: flow, ...opts };
+}
+
+/** A run of `length` flow days starting at `startDay` of January 2026. */
+function run(startId: number, startDay: number, length: number): DayData[] {
+  return Array.from({ length }, (_, i) =>
+    day(startId + i, `2026-01-${String(startDay + i).padStart(2, "0")}`, 2),
+  );
+}
+
+const localDay = (iso: string) => {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+};
+
+describe("groupFlowIntoCycles ignores days with no flow", () => {
+  it("does not let a zero-flow day bridge two cycles", () => {
+    // The private copy in useCyclePhase filtered these out before grouping and
+    // this one did not, so the two disagreed on exactly this input.
+    const data: DayData[] = [
+      day(1, "2026-01-01", 2),
+      day(2, "2026-01-02", 2),
+      day(3, "2026-01-03", 0),
+      day(4, "2026-01-04", 2),
+      day(5, "2026-01-05", 2),
+    ];
+
+    const cycles = groupFlowIntoCycles(data);
+
+    expect(cycles).toHaveLength(2);
+    expect(cycles[0].dates).toEqual(["2026-01-01", "2026-01-02"]);
+    expect(cycles[1].dates).toEqual(["2026-01-04", "2026-01-05"]);
+  });
+
+  it("ignores days with no flow recorded at all", () => {
+    const data: DayData[] = [
+      day(1, "2026-01-01", 2),
+      { id: 2, date: "2026-01-02", flow_intensity: 0, notes: "just a note" },
+      day(3, "2026-01-03", 2),
+    ];
+
+    expect(groupFlowIntoCycles(data)).toHaveLength(2);
+  });
+});
+
+describe("countCompleteCycles", () => {
+  const minimum = CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS;
+
+  it("counts runs that reach the minimum length", () => {
+    expect(
+      countCompleteCycles([...run(1, 1, minimum), ...run(10, 10, minimum)]),
+    ).toBe(2);
+  });
+
+  it("does not count a run shorter than the minimum", () => {
+    expect(countCompleteCycles(run(1, 1, minimum - 1))).toBe(0);
+  });
+
+  it("counts a manually marked cycle start as a new cycle", () => {
+    // The settings screen's gap detection never consulted the markers, so it
+    // saw one long run here and counted one cycle. This counts two.
+    const data: DayData[] = [
+      ...run(1, 1, 3),
+      day(4, "2026-01-04", 2, { is_cycle_start: true }),
+      ...run(5, 5, 2),
+    ];
+
+    expect(countCompleteCycles(data)).toBe(2);
+  });
+
+  it("counts a manually marked cycle end as ending a cycle", () => {
+    const data: DayData[] = [
+      day(1, "2026-01-01", 2),
+      day(2, "2026-01-02", 2),
+      day(3, "2026-01-03", 2, { is_cycle_end: true }),
+      ...run(4, 4, 3),
+    ];
+
+    expect(countCompleteCycles(data)).toBe(2);
+  });
+
+  it("can count fewer cycles than gap detection did, when a marker splits a short run", () => {
+    // Worth knowing: the settings screen's old algorithm saw one three-day run
+    // here and counted 1. Honouring the marker splits it into a one-day and a
+    // two-day run, neither long enough, so the answer is 0. A user who marked
+    // a start mid-run can see their count fall and predictions switch off.
+    const data: DayData[] = [
+      day(1, "2026-01-01", 2),
+      day(2, "2026-01-02", 2, { is_cycle_start: true }),
+      day(3, "2026-01-03", 2),
+    ];
+
+    expect(countCompleteCycles(data)).toBe(0);
+  });
+
+  it("is zero for no flow at all", () => {
+    expect(countCompleteCycles([])).toBe(0);
+  });
+});
+
+describe("determinePhase", () => {
+  it("puts the first days of a cycle in the menstrual phase", () => {
+    expect(determinePhase(1, 28)).toBe("menstrual");
+  });
+
+  it("moves through follicular, ovulation and luteal", () => {
+    const phases = Array.from({ length: 28 }, (_, i) =>
+      determinePhase(i + 1, 28),
+    );
+
+    expect(phases[0]).toBe("menstrual");
+    expect(new Set(phases)).toEqual(
+      new Set(["menstrual", "follicular", "ovulation", "luteal"]),
+    );
+    expect(phases[27]).toBe("luteal");
+  });
+
+  it("shifts its boundaries with the cycle length", () => {
+    // A longer cycle pushes ovulation later.
+    const shortCycle = Array.from({ length: 21 }, (_, i) =>
+      determinePhase(i + 1, 21),
+    ).indexOf("ovulation");
+    const longCycle = Array.from({ length: 35 }, (_, i) =>
+      determinePhase(i + 1, 35),
+    ).indexOf("ovulation");
+
+    expect(longCycle).toBeGreaterThan(shortCycle);
+  });
+});
+
+describe("currentCycleState", () => {
+  const cycleWithFlow = [...run(1, 1, 5)];
+
+  it("is null before any complete cycle is logged", () => {
+    expect(
+      currentCycleState(run(1, 1, 1), [], localDay("2026-01-20")),
+    ).toBeNull();
+  });
+
+  it("counts the cycle day from the last cycle start", () => {
+    const state = currentCycleState(cycleWithFlow, [], localDay("2026-01-11"));
+
+    expect(state?.cycleDay).toBe(11);
+    expect(state?.lastPeriodStart).toBe("2026-01-01");
+  });
+
+  it("takes the reference day as a parameter rather than reading the clock", () => {
+    const early = currentCycleState(cycleWithFlow, [], localDay("2026-01-05"));
+    const later = currentCycleState(cycleWithFlow, [], localDay("2026-01-15"));
+
+    expect(early?.cycleDay).toBe(5);
+    expect(later?.cycleDay).toBe(15);
+  });
+
+  it("calls today menstrual whenever flow is logged for today", () => {
+    // The old code compared a UTC-formatted "today" against local date
+    // strings, so after 5pm Pacific this check asked about tomorrow.
+    const state = currentCycleState(cycleWithFlow, [], localDay("2026-01-03"));
+
+    expect(state?.currentPhase).toBe("menstrual");
+  });
+
+  it("reports the next predicted start and its confidence", () => {
+    const state = currentCycleState(
+      cycleWithFlow,
+      [{ date: "2026-02-01", confidence: 72 }],
+      localDay("2026-01-11"),
+    );
+
+    expect(state?.nextPredictedStart).toBe("2026-02-01");
+    expect(state?.confidence).toBe(72);
+  });
+
+  it("reports zero confidence when nothing is predicted", () => {
+    const state = currentCycleState(cycleWithFlow, [], localDay("2026-01-11"));
+
+    expect(state?.confidence).toBe(0);
+    expect(state?.nextPredictedStart).toBeNull();
+  });
+
+  it("gates on the same count the settings screen uses", () => {
+    const oneCycle = currentCycleState(
+      cycleWithFlow,
+      [],
+      localDay("2026-01-11"),
+    );
+
+    expect(oneCycle?.hasEnoughData).toBe(
+      countCompleteCycles(cycleWithFlow) >=
+        CYCLE_PREDICTION_CONSTANTS.MIN_CYCLES_FOR_PREDICTION,
+    );
+  });
+});
+
+describe("cycleStats", () => {
+  it("is null before any complete cycle is logged", () => {
+    expect(cycleStats(run(1, 1, 1), 0)).toBeNull();
+  });
+
+  it("reports the same cycle count as countCompleteCycles", () => {
+    const data = [...run(1, 1, 4), ...run(10, 10, 4)];
+
+    expect(cycleStats(data, 0)?.totalCyclesTracked).toBe(
+      countCompleteCycles(data),
+    );
+  });
+
+  it("passes prediction accuracy straight through", () => {
+    expect(cycleStats(run(1, 1, 4), 83)?.predictionAccuracy).toBe(83);
+  });
+
+  it("calls a cycle regular when variation is small", () => {
+    const stats = cycleStats(run(1, 1, 4), 0);
+
+    expect(stats?.cycleVariation).toBe(
+      calculateCycleVariation(groupFlowIntoCycles(run(1, 1, 4))),
+    );
+    expect(stats?.isRegular).toBe(true);
+  });
+});

--- a/app/(pregnancy-tabs)/index.tsx
+++ b/app/(pregnancy-tabs)/index.tsx
@@ -10,11 +10,8 @@ import { getSetting } from "@/db/database";
 import { SettingsKeys } from "@/constants/Settings";
 import { getBabySizeForWeek, PREGNANCY_WEEKS } from "@/constants/Pregnancy";
 import { usePregnancySetup } from "@/hooks/usePregnancySetup";
-import {
-  formatDueDate,
-  gestationalAge,
-  startOfLocalDay,
-} from "@/utils/pregnancyDates";
+import { startOfLocalDay } from "@/utils/dates";
+import { formatDueDate, gestationalAge } from "@/utils/pregnancyDates";
 
 export default function PregnancyHome() {
   const theme = useTheme();

--- a/app/(pregnancy-tabs)/info.tsx
+++ b/app/(pregnancy-tabs)/info.tsx
@@ -19,7 +19,8 @@ import {
   getPregnancyWeekContent,
   getTrimesterLabel,
 } from "@/constants/Pregnancy";
-import { gestationalAge, startOfLocalDay } from "@/utils/pregnancyDates";
+import { startOfLocalDay } from "@/utils/dates";
+import { gestationalAge } from "@/utils/pregnancyDates";
 
 // The idea here is that this tab will eventually be up to date with whatever week the user is at
 // Placeholder is week 5, but by the end of pregnancy tracking implementation, this tab *should* be providing information accurate

--- a/app/(tabs)/cycle.tsx
+++ b/app/(tabs)/cycle.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import {
   StyleSheet,
   View,
@@ -15,6 +15,7 @@ import PhaseCard from "@/components/cycle/PhaseCard";
 import CycleStatsCard from "@/components/cycle/CycleStatsCard";
 import TipsCard from "@/components/cycle/TipsCard";
 import { useCyclePhase } from "@/hooks/useCyclePhase";
+import { startOfLocalDay } from "@/utils/dates";
 import {
   useData,
   usePredictedCycle,
@@ -116,9 +117,11 @@ export default function Cycle() {
   const { databaseChange } = useDatabaseChangeNotifier();
   const { predictionChoice } = usePredictionChoice();
   const { fetchCycleData } = useFetchCycleData(setPredictedCycle);
+  const today = useMemo(() => startOfLocalDay(), []);
   const { cycleState, stats, loading, refresh } = useCyclePhase(
     flowData,
     predictedCycle,
+    today,
   );
 
   // Load cycle data on mount and when database changes

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,7 +10,7 @@ import {
 import { getFlowTypeString } from "@/constants/Flow";
 import { useTheme, Text, Button } from "react-native-paper";
 import FadeInView from "@/components/animations/FadeInView";
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import {
   getActiveBirthControlType,
   quickLogBirthControlForToday,
@@ -18,6 +18,7 @@ import {
   LONG_TERM_BC_TYPES,
 } from "@/db/quickBirthControl";
 import { useCyclePhase } from "@/hooks/useCyclePhase";
+import { startOfLocalDay } from "@/utils/dates";
 import { CYCLE_PHASES } from "@/constants/CyclePhases";
 import { useRouter } from "expo-router";
 import { useFetchCycleData } from "@/hooks/useFetchCycleData";
@@ -35,9 +36,11 @@ export default function HomeScreen() {
   const { setDatabaseChange, databaseChange } = useDatabaseChangeNotifier();
   const { predictedCycle, setPredictedCycle } = usePredictedCycle();
   const { fetchCycleData } = useFetchCycleData(setPredictedCycle);
+  const today = useMemo(() => startOfLocalDay(), []);
   const { cycleState, loading: cycleLoading } = useCyclePhase(
     flowData,
     predictedCycle,
+    today,
   );
 
   // Load cycle data on mount and when database changes

--- a/components/pregnancy/PregnancySetupDialog.tsx
+++ b/components/pregnancy/PregnancySetupDialog.tsx
@@ -14,7 +14,7 @@ import {
   MAX_DAY_IN_WEEK_INPUT,
   MAX_PREGNANCY_WEEK_INPUT,
 } from "@/constants/Pregnancy";
-import { formatAsISODate } from "@/utils/pregnancyDates";
+import { formatAsISODate } from "@/utils/dates";
 import type {
   DateFieldKey,
   NotSurePath,

--- a/components/settings/CyclePrediction.tsx
+++ b/components/settings/CyclePrediction.tsx
@@ -24,6 +24,11 @@ import {
   deleteAllPredictionSnapshots,
 } from "@/db/database";
 import { CYCLE_PREDICTION_CONSTANTS } from "@/constants/CyclePrediction";
+import {
+  countCompleteCycles,
+  hasEnoughCyclesForPrediction,
+} from "@/services/cyclePredictionLogic";
+import type { DayData } from "@/constants/Interfaces";
 
 export default function CyclePredictions() {
   const theme = useTheme();
@@ -81,40 +86,13 @@ export default function CyclePredictions() {
           return;
         }
 
-        // Count cycles
-        let cycleCount = 0;
-        let consecutiveDays = 0;
-        const sortedDays = flowDays.sort(
-          (a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf(),
-        );
+        // One definition of a Cycle, shared with the cycle tab. This used to
+        // be its own gap-detection pass that never consulted the
+        // is_cycle_start / is_cycle_end markers, so marking a cycle start
+        // changed what the cycle tab said and not what this screen said.
+        const cycleCount = countCompleteCycles(flowDays as DayData[]);
 
-        for (let i = 0; i < sortedDays.length; i++) {
-          const currentDate = new Date(sortedDays[i].date);
-          const nextDate =
-            i < sortedDays.length - 1 ? new Date(sortedDays[i + 1].date) : null;
-
-          consecutiveDays++;
-
-          const isLastDay = i === sortedDays.length - 1;
-          const isGap = nextDate
-            ? (nextDate.getTime() - currentDate.getTime()) /
-                (1000 * 60 * 60 * 24) >
-              1
-            : false;
-
-          if (
-            (isLastDay || isGap) &&
-            consecutiveDays >= CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS
-          ) {
-            cycleCount++;
-            consecutiveDays = 0;
-          } else if (isGap) {
-            consecutiveDays = 0;
-          }
-        }
-
-        const hasEnough =
-          cycleCount >= CYCLE_PREDICTION_CONSTANTS.MIN_CYCLES_FOR_PREDICTION;
+        const hasEnough = hasEnoughCyclesForPrediction(flowDays as DayData[]);
         let message = "";
 
         if (hasEnough) {

--- a/constants/CyclePrediction.ts
+++ b/constants/CyclePrediction.ts
@@ -18,6 +18,9 @@ export const CYCLE_PREDICTION_CONSTANTS = {
   /** Minimum consecutive flow days to consider it a valid cycle */
   MIN_CONSECUTIVE_DAYS: 3,
 
+  /** Standard deviation, in days, at or below which a cycle reads as regular */
+  REGULAR_VARIATION_DAYS: 3,
+
   /** Number of months to predict ahead */
   PREDICTION_MONTHS_AHEAD: 3,
 

--- a/hooks/useCyclePhase.ts
+++ b/hooks/useCyclePhase.ts
@@ -1,22 +1,12 @@
-import { useMemo, useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
-  DayData,
-  PredictedDate,
   CurrentCycleState,
   CycleStats,
+  DayData,
+  PredictedDate,
 } from "@/constants/Interfaces";
-import {
-  CyclePhaseId,
-  getAdjustedPhaseBoundaries,
-} from "@/constants/CyclePhases";
-import { CYCLE_PREDICTION_CONSTANTS } from "@/constants/CyclePrediction";
+import { currentCycleState, cycleStats } from "@/services/cyclePredictionLogic";
 import { getPredictionAccuracy } from "@/db/database";
-
-interface GroupedCycle {
-  dates: string[];
-  startDate: string;
-  endDate: string;
-}
 
 interface UseCyclePhaseResult {
   cycleState: CurrentCycleState | null;
@@ -26,158 +16,21 @@ interface UseCyclePhaseResult {
 }
 
 /**
- * Check if two dates are consecutive calendar days
- */
-function areConsecutive(date1: string, date2: string): boolean {
-  const d1 = new Date(date1 + "T00:00:00");
-  const d2 = new Date(date2 + "T00:00:00");
-  const utcDate1 = Date.UTC(d1.getFullYear(), d1.getMonth(), d1.getDate());
-  const utcDate2 = Date.UTC(d2.getFullYear(), d2.getMonth(), d2.getDate());
-  const diffDays = Math.abs((utcDate2 - utcDate1) / (1000 * 60 * 60 * 24));
-  return diffDays === 1;
-}
-
-/**
- * Group consecutive flow days into cycles
- */
-function groupIntoCycles(flowData: DayData[]): GroupedCycle[] {
-  const sortedFlowDays = [...flowData]
-    .filter((day) => day.flow_intensity && day.flow_intensity > 0)
-    .sort((a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf());
-
-  if (sortedFlowDays.length === 0) return [];
-
-  const cycles: GroupedCycle[] = [];
-  let lastDate: string | null = null;
-
-  sortedFlowDays.forEach((data) => {
-    const isNewCycleStart = data.is_cycle_start === true;
-    const isPreviousCycleEnd =
-      cycles.length > 0 &&
-      cycles[cycles.length - 1].endDate === lastDate &&
-      flowData.find((d) => d.date === lastDate)?.is_cycle_end === true;
-
-    const shouldStartNewCycle =
-      isNewCycleStart ||
-      isPreviousCycleEnd ||
-      !lastDate ||
-      !areConsecutive(lastDate, data.date);
-
-    if (lastDate && !shouldStartNewCycle) {
-      const lastCycle = cycles[cycles.length - 1];
-      lastCycle.dates.push(data.date);
-      lastCycle.endDate = data.date;
-    } else {
-      cycles.push({
-        dates: [data.date],
-        startDate: data.date,
-        endDate: data.date,
-      });
-    }
-
-    lastDate = data.date;
-  });
-
-  return cycles;
-}
-
-/**
- * Calculate average cycle length from historical cycles
- */
-function calculateAverageCycleLength(cycles: GroupedCycle[]): number {
-  const validCycles = cycles.filter(
-    (cycle) =>
-      cycle.dates.length >= CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS,
-  );
-
-  if (validCycles.length < 2) {
-    return CYCLE_PREDICTION_CONSTANTS.DEFAULT_CYCLE_LENGTH;
-  }
-
-  const cycleLengths: number[] = [];
-  for (let i = 1; i < validCycles.length; i++) {
-    const prevStart = new Date(validCycles[i - 1].startDate + "T00:00:00");
-    const currStart = new Date(validCycles[i].startDate + "T00:00:00");
-    const diffDays = Math.round(
-      (currStart.getTime() - prevStart.getTime()) / (1000 * 60 * 60 * 24),
-    );
-
-    if (
-      diffDays >= CYCLE_PREDICTION_CONSTANTS.MIN_CYCLE_LENGTH &&
-      diffDays <= CYCLE_PREDICTION_CONSTANTS.MAX_CYCLE_LENGTH
-    ) {
-      cycleLengths.push(diffDays);
-    }
-  }
-
-  if (cycleLengths.length === 0) {
-    return CYCLE_PREDICTION_CONSTANTS.DEFAULT_CYCLE_LENGTH;
-  }
-
-  return Math.round(
-    cycleLengths.reduce((a, b) => a + b, 0) / cycleLengths.length,
-  );
-}
-
-/**
- * Calculate cycle variation (standard deviation)
- */
-function calculateCycleVariation(cycles: GroupedCycle[]): number {
-  const validCycles = cycles.filter(
-    (cycle) =>
-      cycle.dates.length >= CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS,
-  );
-
-  if (validCycles.length < 2) return 0;
-
-  const cycleLengths: number[] = [];
-  for (let i = 1; i < validCycles.length; i++) {
-    const prevStart = new Date(validCycles[i - 1].startDate + "T00:00:00");
-    const currStart = new Date(validCycles[i].startDate + "T00:00:00");
-    const diffDays = Math.round(
-      (currStart.getTime() - prevStart.getTime()) / (1000 * 60 * 60 * 24),
-    );
-
-    if (
-      diffDays >= CYCLE_PREDICTION_CONSTANTS.MIN_CYCLE_LENGTH &&
-      diffDays <= CYCLE_PREDICTION_CONSTANTS.MAX_CYCLE_LENGTH
-    ) {
-      cycleLengths.push(diffDays);
-    }
-  }
-
-  if (cycleLengths.length < 2) return 0;
-
-  const avg = cycleLengths.reduce((a, b) => a + b, 0) / cycleLengths.length;
-  const variance =
-    cycleLengths.reduce((sum, len) => sum + Math.pow(len - avg, 2), 0) /
-    cycleLengths.length;
-  return Math.round(Math.sqrt(variance) * 10) / 10;
-}
-
-/**
- * Determine current phase based on cycle day
- */
-function determinePhase(cycleDay: number, cycleLength: number): CyclePhaseId {
-  const boundaries = getAdjustedPhaseBoundaries(cycleLength);
-
-  if (cycleDay <= boundaries.menstrualEnd) {
-    return "menstrual";
-  } else if (cycleDay <= boundaries.follicularEnd) {
-    return "follicular";
-  } else if (cycleDay <= boundaries.ovulationEnd) {
-    return "ovulation";
-  } else {
-    return "luteal";
-  }
-}
-
-/**
- * Hook to calculate current cycle phase and statistics
+ * Subscribes to prediction accuracy and hands the cycle rules their inputs.
+ *
+ * The rules themselves live in services/cyclePredictionLogic.ts, which is the
+ * one definition of a Cycle. This file used to carry a private copy of the
+ * grouping, average length, variation and phase logic; that copy answered
+ * differently and could not be tested, because it imported the database and
+ * called new Date() inside a memo.
+ *
+ * `referenceDay` is a parameter for the same reason it is one everywhere else
+ * in this module: the caller owns "today".
  */
 export function useCyclePhase(
   flowData: DayData[],
   predictedCycle: PredictedDate[],
+  referenceDay: Date,
 ): UseCyclePhaseResult {
   const [loading, setLoading] = useState(true);
   const [predictionAccuracy, setPredictionAccuracy] = useState(0);
@@ -196,95 +49,15 @@ export function useCyclePhase(
     loadAccuracy().finally(() => setLoading(false));
   }, [loadAccuracy]);
 
-  const cycles = useMemo(() => groupIntoCycles(flowData), [flowData]);
-
-  const validCycles = useMemo(
-    () =>
-      cycles.filter(
-        (cycle) =>
-          cycle.dates.length >= CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS,
-      ),
-    [cycles],
+  const cycleState = useMemo(
+    () => currentCycleState(flowData, predictedCycle, referenceDay),
+    [flowData, predictedCycle, referenceDay],
   );
 
-  const cycleState = useMemo((): CurrentCycleState | null => {
-    if (validCycles.length === 0) {
-      return null;
-    }
-
-    const lastCycle = validCycles[validCycles.length - 1];
-    const cycleLength = calculateAverageCycleLength(cycles);
-
-    const today = new Date();
-    const todayStr = today.toISOString().split("T")[0];
-    const lastStart = new Date(lastCycle.startDate + "T00:00:00");
-
-    // Calculate days since last period started
-    const daysSinceStart = Math.floor(
-      (today.getTime() - lastStart.getTime()) / (1000 * 60 * 60 * 24),
-    );
-
-    // Cycle day (1-indexed, wraps around)
-    let cycleDay = (daysSinceStart % cycleLength) + 1;
-    if (daysSinceStart < 0) cycleDay = 1;
-
-    // Check if currently on period (has flow logged today)
-    const todayData = flowData.find((d) => d.date === todayStr);
-    const isCurrentlyOnPeriod =
-      todayData && todayData.flow_intensity && todayData.flow_intensity > 0;
-
-    // Determine phase
-    let currentPhase = determinePhase(cycleDay, cycleLength);
-
-    // Override to menstrual if currently bleeding
-    if (isCurrentlyOnPeriod) {
-      currentPhase = "menstrual";
-    }
-
-    // Days until next period
-    const daysUntilNextPeriod = cycleLength - cycleDay + 1;
-
-    // Next predicted start date
-    const nextPredictedStart =
-      predictedCycle.length > 0 ? predictedCycle[0].date : null;
-
-    // Confidence from predictions; 0 when no predictions (UI shows "Low confidence")
-    const confidence =
-      predictedCycle.length > 0 ? predictedCycle[0].confidence : 0;
-
-    // Need at least 2 cycles for reliable predictions
-    const hasEnoughData =
-      validCycles.length >=
-      CYCLE_PREDICTION_CONSTANTS.MIN_CYCLES_FOR_PREDICTION;
-
-    return {
-      currentPhase,
-      cycleDay,
-      cycleLength,
-      daysUntilNextPeriod,
-      lastPeriodStart: lastCycle.startDate,
-      nextPredictedStart,
-      confidence,
-      hasEnoughData,
-    };
-  }, [validCycles, cycles, flowData, predictedCycle]);
-
-  const stats = useMemo((): CycleStats | null => {
-    if (validCycles.length === 0) {
-      return null;
-    }
-
-    const avgLength = calculateAverageCycleLength(cycles);
-    const variation = calculateCycleVariation(cycles);
-
-    return {
-      averageCycleLength: avgLength,
-      cycleVariation: variation,
-      totalCyclesTracked: validCycles.length,
-      predictionAccuracy,
-      isRegular: variation <= 3,
-    };
-  }, [cycles, validCycles, predictionAccuracy]);
+  const stats = useMemo(
+    () => cycleStats(flowData, predictionAccuracy),
+    [flowData, predictionAccuracy],
+  );
 
   const refresh = useCallback(async () => {
     setLoading(true);

--- a/hooks/usePregnancySetup.ts
+++ b/hooks/usePregnancySetup.ts
@@ -27,11 +27,10 @@ import type {
   NotSurePath,
   SetupMethod,
 } from "@/components/pregnancy/pregnancySetupTypes";
+import { addDays, startOfLocalDay } from "@/utils/dates";
 import {
-  addDays,
   anchorFromSetupAnswer,
   gestationalAge,
-  startOfLocalDay,
   type SetupAnswer,
 } from "@/utils/pregnancyDates";
 

--- a/services/cyclePredictionLogic.ts
+++ b/services/cyclePredictionLogic.ts
@@ -4,8 +4,18 @@
  * Used by useFetchCycleData; designed for testability with no DB dependency.
  */
 
-import { DayData, PredictedDate } from "@/constants/Interfaces";
+import {
+  CurrentCycleState,
+  CycleStats,
+  DayData,
+  PredictedDate,
+} from "@/constants/Interfaces";
 import { CYCLE_PREDICTION_CONSTANTS } from "@/constants/CyclePrediction";
+import {
+  CyclePhaseId,
+  getAdjustedPhaseBoundaries,
+} from "@/constants/CyclePhases";
+import { differenceInDays, formatAsISODate, parseISODate } from "@/utils/dates";
 
 export interface GroupedCycle {
   dates: string[];
@@ -15,8 +25,8 @@ export interface GroupedCycle {
 }
 
 export interface GeneratePredictionsOptions {
-  /** Reference "today" for future-only predictions (default: new Date()) */
-  referenceDate?: Date;
+  /** Reference "today" for future-only predictions. Required: no clock reads. */
+  referenceDate: Date;
   /** Max future cycles to predict (default: from constants) */
   maxFutureCycles?: number;
 }
@@ -39,9 +49,12 @@ export function areConsecutive(date1: string, date2: string): boolean {
  * Respects manual cycle start/end markers when present.
  */
 export function groupFlowIntoCycles(flowData: DayData[]): GroupedCycle[] {
-  const sorted = [...flowData].sort(
-    (a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf(),
-  );
+  // Days with no flow are not part of a Cycle, and letting one through bridges
+  // two Cycles into one. The private copy in useCyclePhase filtered first and
+  // this one did not, which is one of the ways the two answers diverged.
+  const sorted = flowData
+    .filter((d) => (d.flow_intensity ?? 0) > 0)
+    .sort((a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf());
   let lastDate: string | null = null;
   const grouped: GroupedCycle[] = [];
 
@@ -50,7 +63,7 @@ export function groupFlowIntoCycles(flowData: DayData[]): GroupedCycle[] {
     const isPreviousCycleEnd =
       grouped.length > 0 &&
       grouped[grouped.length - 1].endDate === lastDate &&
-      flowData.find((d) => d.date === lastDate)?.is_cycle_end === true;
+      sorted.find((d) => d.date === lastDate)?.is_cycle_end === true;
     const shouldStartNewCycle =
       isNewCycleStart ||
       isPreviousCycleEnd ||
@@ -88,20 +101,7 @@ export function calculateAverageCycleLength(cycles: GroupedCycle[]): number {
     return CYCLE_PREDICTION_CONSTANTS.DEFAULT_CYCLE_LENGTH;
   }
 
-  const cycleLengths: number[] = [];
-  for (let i = 1; i < validCycles.length; i++) {
-    const prev = new Date(validCycles[i - 1].startDate + "T00:00:00");
-    const curr = new Date(validCycles[i].startDate + "T00:00:00");
-    const diffDays = Math.round(
-      (curr.getTime() - prev.getTime()) / (1000 * 60 * 60 * 24),
-    );
-    if (
-      diffDays >= CYCLE_PREDICTION_CONSTANTS.MIN_CYCLE_LENGTH &&
-      diffDays <= CYCLE_PREDICTION_CONSTANTS.MAX_CYCLE_LENGTH
-    ) {
-      cycleLengths.push(diffDays);
-    }
-  }
+  const cycleLengths = cycleLengthsBetween(validCycles);
 
   if (cycleLengths.length === 0) {
     return CYCLE_PREDICTION_CONSTANTS.DEFAULT_CYCLE_LENGTH;
@@ -111,13 +111,37 @@ export function calculateAverageCycleLength(cycles: GroupedCycle[]): number {
 }
 
 /**
+ * Gaps between the starts of consecutive cycles, keeping only the plausible
+ * ones. Shared by average length and variation, which computed it separately
+ * and identically.
+ */
+export function cycleLengthsBetween(cycles: GroupedCycle[]): number[] {
+  const lengths: number[] = [];
+  for (let i = 1; i < cycles.length; i++) {
+    const days = differenceInDays(
+      parseISODate(cycles[i - 1].startDate),
+      parseISODate(cycles[i].startDate),
+    );
+    if (
+      days >= CYCLE_PREDICTION_CONSTANTS.MIN_CYCLE_LENGTH &&
+      days <= CYCLE_PREDICTION_CONSTANTS.MAX_CYCLE_LENGTH
+    ) {
+      lengths.push(days);
+    }
+  }
+  return lengths;
+}
+
+/**
  * Calculate confidence score (0–100) from cycle regularity, amount of data, and recency.
- * referenceDate is used for recency; defaults to now when omitted.
+ *
+ * referenceDate is required. A default that reads the clock is a hidden input,
+ * and it is what made the copy of this rule in useCyclePhase untestable.
  */
 export function calculateConfidence(
   cycles: GroupedCycle[],
   cycleLengths: number[],
-  referenceDate: Date = new Date(),
+  referenceDate: Date,
 ): number {
   if (cycleLengths.length < 2) {
     return 30;
@@ -169,11 +193,9 @@ export function calculateConfidence(
  */
 export function generatePredictions(
   flowData: DayData[],
-  options: GeneratePredictionsOptions = {},
+  options: GeneratePredictionsOptions,
 ): PredictedDate[] {
-  const referenceDate = options.referenceDate
-    ? new Date(options.referenceDate)
-    : new Date();
+  const referenceDate = new Date(options.referenceDate);
   const maxCycles =
     options.maxFutureCycles ?? CYCLE_PREDICTION_CONSTANTS.MAX_FUTURE_CYCLES;
 
@@ -243,4 +265,136 @@ export function generatePredictions(
   }
 
   return predictedDates;
+}
+
+/**
+ * Cycles long enough to count, by the definition above.
+ *
+ * This is the one answer to "how many cycles have I logged?". The settings
+ * screen used to compute its own with pure gap detection that never consulted
+ * the is_cycle_start / is_cycle_end markers, so marking a cycle start changed
+ * what the cycle tab said and not what settings said.
+ */
+export function completeCycles(flowData: DayData[]): GroupedCycle[] {
+  return groupFlowIntoCycles(flowData).filter(
+    (cycle) =>
+      cycle.dates.length >= CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS,
+  );
+}
+
+export function countCompleteCycles(flowData: DayData[]): number {
+  return completeCycles(flowData).length;
+}
+
+export function hasEnoughCyclesForPrediction(flowData: DayData[]): boolean {
+  return (
+    countCompleteCycles(flowData) >=
+    CYCLE_PREDICTION_CONSTANTS.MIN_CYCLES_FOR_PREDICTION
+  );
+}
+
+/** Standard deviation of cycle lengths, to one decimal place. */
+export function calculateCycleVariation(cycles: GroupedCycle[]): number {
+  const lengths = cycleLengthsBetween(
+    cycles.filter(
+      (c) => c.dates.length >= CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS,
+    ),
+  );
+  if (lengths.length < 2) return 0;
+
+  const average = lengths.reduce((a, b) => a + b, 0) / lengths.length;
+  const variance =
+    lengths.reduce((sum, length) => sum + Math.pow(length - average, 2), 0) /
+    lengths.length;
+  return Math.round(Math.sqrt(variance) * 10) / 10;
+}
+
+/**
+ * Which phase a given cycle day falls in.
+ *
+ * Boundaries come from constants/CyclePhases.ts, which scales them to the
+ * cycle length. This was retyped privately in useCyclePhase beside the tested
+ * accessor it was already calling.
+ */
+export function determinePhase(
+  cycleDay: number,
+  cycleLength: number,
+): CyclePhaseId {
+  const boundaries = getAdjustedPhaseBoundaries(cycleLength);
+
+  if (cycleDay <= boundaries.menstrualEnd) return "menstrual";
+  if (cycleDay <= boundaries.follicularEnd) return "follicular";
+  if (cycleDay <= boundaries.ovulationEnd) return "ovulation";
+  return "luteal";
+}
+
+/**
+ * Where the user is in their cycle on `referenceDay`.
+ *
+ * Null until at least one complete Cycle exists, since there is nothing to
+ * count from. `referenceDay` is a parameter: this rule lived inside a memo
+ * that called `new Date()` inline, which is why it had no tests.
+ */
+export function currentCycleState(
+  flowData: DayData[],
+  predictedCycle: PredictedDate[],
+  referenceDay: Date,
+): CurrentCycleState | null {
+  const cycles = groupFlowIntoCycles(flowData);
+  const valid = cycles.filter(
+    (c) => c.dates.length >= CYCLE_PREDICTION_CONSTANTS.MIN_CONSECUTIVE_DAYS,
+  );
+  if (valid.length === 0) return null;
+
+  const lastCycle = valid[valid.length - 1];
+  const cycleLength = calculateAverageCycleLength(cycles);
+
+  const daysSinceStart = differenceInDays(
+    parseISODate(lastCycle.startDate),
+    referenceDay,
+  );
+
+  let cycleDay = (daysSinceStart % cycleLength) + 1;
+  if (daysSinceStart < 0) cycleDay = 1;
+
+  // Local, not UTC. Formatting the reference day with toISOString asked about
+  // tomorrow for anyone west of UTC after their afternoon.
+  const referenceDate = formatAsISODate(referenceDay);
+  const isCurrentlyBleeding = flowData.some(
+    (d) => d.date === referenceDate && (d.flow_intensity ?? 0) > 0,
+  );
+
+  return {
+    currentPhase: isCurrentlyBleeding
+      ? "menstrual"
+      : determinePhase(cycleDay, cycleLength),
+    cycleDay,
+    cycleLength,
+    daysUntilNextPeriod: cycleLength - cycleDay + 1,
+    lastPeriodStart: lastCycle.startDate,
+    nextPredictedStart:
+      predictedCycle.length > 0 ? predictedCycle[0].date : null,
+    confidence: predictedCycle.length > 0 ? predictedCycle[0].confidence : 0,
+    hasEnoughData: hasEnoughCyclesForPrediction(flowData),
+  };
+}
+
+/** Summary statistics for the cycle tab. Null until a complete Cycle exists. */
+export function cycleStats(
+  flowData: DayData[],
+  predictionAccuracy: number,
+): CycleStats | null {
+  const cycles = groupFlowIntoCycles(flowData);
+  const valid = completeCycles(flowData);
+  if (valid.length === 0) return null;
+
+  const variation = calculateCycleVariation(cycles);
+
+  return {
+    averageCycleLength: calculateAverageCycleLength(cycles),
+    cycleVariation: variation,
+    totalCyclesTracked: valid.length,
+    predictionAccuracy,
+    isRegular: variation <= CYCLE_PREDICTION_CONSTANTS.REGULAR_VARIATION_DAYS,
+  };
 }

--- a/utils/__tests__/dates.test.ts
+++ b/utils/__tests__/dates.test.ts
@@ -1,0 +1,45 @@
+import { addDays, differenceInDays, formatAsISODate } from "@/utils/dates";
+
+const day = (iso: string) => {
+  const [year, month, date] = iso.split("-").map(Number);
+  return new Date(year, month - 1, date);
+};
+
+describe("differenceInDays", () => {
+  it("counts calendar days", () => {
+    expect(differenceInDays(day("2026-03-01"), day("2026-03-08"))).toBe(7);
+  });
+
+  it("is not thrown off by a daylight saving transition", () => {
+    // Raw millisecond division floors this to 83 in any timezone that springs
+    // forward in March, which is most of the ones users are in.
+    expect(differenceInDays(day("2026-03-01"), day("2026-05-24"))).toBe(84);
+    expect(differenceInDays(day("2026-11-01"), day("2026-11-30"))).toBe(29);
+  });
+
+  it("goes negative in the other direction", () => {
+    expect(differenceInDays(day("2026-03-08"), day("2026-03-01"))).toBe(-7);
+  });
+});
+
+describe("formatAsISODate", () => {
+  it("formats in local time, not UTC", () => {
+    // 23:30 local on the 1st is the 2nd in UTC anywhere east of it. The app
+    // stores and compares calendar days, so local is the right answer.
+    expect(formatAsISODate(new Date(2026, 2, 1, 23, 30))).toBe("2026-03-01");
+  });
+
+  it("pads single-digit months and days", () => {
+    expect(formatAsISODate(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});
+
+describe("addDays", () => {
+  it("moves by calendar days across a daylight saving transition", () => {
+    expect(formatAsISODate(addDays(day("2026-03-07"), 2))).toBe("2026-03-09");
+  });
+
+  it("goes backwards", () => {
+    expect(formatAsISODate(addDays(day("2026-01-01"), -1))).toBe("2025-12-31");
+  });
+});

--- a/utils/__tests__/pregnancyDates.test.ts
+++ b/utils/__tests__/pregnancyDates.test.ts
@@ -3,10 +3,9 @@ import {
   FULL_TERM_DAYS,
   CONCEPTION_TO_CURRENT_DAY_OFFSET,
 } from "@/constants/Pregnancy";
+import { formatAsISODate } from "@/utils/dates";
 import {
   anchorFromSetupAnswer,
-  differenceInDays,
-  formatAsISODate,
   gestationalAge,
   type SetupAnswer,
 } from "@/utils/pregnancyDates";
@@ -15,23 +14,6 @@ const day = (iso: string) => {
   const [year, month, date] = iso.split("-").map(Number);
   return new Date(year, month - 1, date);
 };
-
-describe("differenceInDays", () => {
-  it("counts calendar days", () => {
-    expect(differenceInDays(day("2026-03-01"), day("2026-03-08"))).toBe(7);
-  });
-
-  it("is not thrown off by a daylight saving transition", () => {
-    // Raw millisecond division floors this to 83 in any timezone that springs
-    // forward in March, which is most of the ones users are in.
-    expect(differenceInDays(day("2026-03-01"), day("2026-05-24"))).toBe(84);
-    expect(differenceInDays(day("2026-11-01"), day("2026-11-30"))).toBe(29);
-  });
-
-  it("goes negative in the other direction", () => {
-    expect(differenceInDays(day("2026-03-08"), day("2026-03-01"))).toBe(-7);
-  });
-});
 
 describe("gestationalAge", () => {
   it("counts the pregnancy day from the start date plus the offset", () => {

--- a/utils/dates.ts
+++ b/utils/dates.ts
@@ -1,0 +1,50 @@
+/**
+ * Calendar-day arithmetic, in local time. Belongs to neither tracking mode.
+ *
+ * Every function here treats a Date as a calendar day and ignores its time of
+ * day. That is the property the app actually needs: days are stored as
+ * "YYYY-MM-DD" strings and compared as days, never as instants.
+ */
+export const formatAsISODate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const parseISODate = (value: string): Date => {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, month - 1, day);
+};
+
+/**
+ * Whole calendar days between two local dates.
+ *
+ * Both dates are rebuilt through `Date.UTC` from their calendar components
+ * first. Dividing raw millisecond deltas is off by one across a daylight
+ * saving transition: a span of 84 calendar days that crosses spring-forward is
+ * 84 days minus an hour, and flooring that gives 83. This is the same
+ * treatment services/cyclePredictionLogic.ts:31 already uses.
+ */
+export const differenceInDays = (startDate: Date, endDate: Date): number => {
+  const start = Date.UTC(
+    startDate.getFullYear(),
+    startDate.getMonth(),
+    startDate.getDate(),
+  );
+  const end = Date.UTC(
+    endDate.getFullYear(),
+    endDate.getMonth(),
+    endDate.getDate(),
+  );
+  return Math.round((end - start) / (1000 * 60 * 60 * 24));
+};
+
+export const addDays = (base: Date, days: number): Date => {
+  const next = new Date(base);
+  next.setDate(next.getDate() + days);
+  return next;
+};
+
+export const startOfLocalDay = (date: Date = new Date()): Date =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());

--- a/utils/pregnancyDates.ts
+++ b/utils/pregnancyDates.ts
@@ -7,52 +7,15 @@ import {
   getTrimesterLabel,
 } from "@/constants/Pregnancy";
 
-export const formatAsISODate = (date: Date): string => {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
-
-export const parseISODate = (value: string): Date => {
-  const [year, month, day] = value.split("-").map(Number);
-  return new Date(year, month - 1, day);
-};
-
-/**
- * Whole calendar days between two local dates.
- *
- * Both dates are rebuilt through `Date.UTC` from their calendar components
- * first. Dividing raw millisecond deltas is off by one across a daylight
- * saving transition: a span of 84 calendar days that crosses spring-forward is
- * 84 days minus an hour, and flooring that gives 83. This is the same
- * treatment services/cyclePredictionLogic.ts:31 already uses.
- */
-export const differenceInDays = (startDate: Date, endDate: Date): number => {
-  const start = Date.UTC(
-    startDate.getFullYear(),
-    startDate.getMonth(),
-    startDate.getDate(),
-  );
-  const end = Date.UTC(
-    endDate.getFullYear(),
-    endDate.getMonth(),
-    endDate.getDate(),
-  );
-  return Math.round((end - start) / (1000 * 60 * 60 * 24));
-};
-
-export const addDays = (base: Date, days: number): Date => {
-  const next = new Date(base);
-  next.setDate(next.getDate() + days);
-  return next;
-};
+import {
+  addDays,
+  differenceInDays,
+  formatAsISODate,
+  parseISODate,
+} from "@/utils/dates";
 
 export const formatDueDate = (date: Date): string =>
   date.toLocaleDateString(undefined, { month: "long", day: "numeric" });
-
-export const startOfLocalDay = (date: Date = new Date()): Date =>
-  new Date(date.getFullYear(), date.getMonth(), date.getDate());
 
 /**
  * The derived view of a pregnancy. Nothing here is stored; it is all a


### PR DESCRIPTION
Closes #186.

**Stacked.** Merge order: #191 → #193 → #194 → #195 → #196 → #197 → #198 → #199 → this.

`hooks/useCyclePhase.ts`: **296 lines → 71.**

## The issue is slightly wrong, and the correction matters

The issue calls `useCyclePhase.ts:43-82` a *"verbatim, module-private copy"*. It is not verbatim. It filters `flow_intensity > 0` before grouping; `cyclePredictionLogic.ts:41` does not. So a zero-flow day sitting between two flow runs bridged them into one cycle in the tested function and split them in the hook's copy.

Before changing anything I checked what actually reaches the hook: `useData` is populated only by `useFetchFlowData.ts:9`, which already filters `day.flow_intensity`. So the filter is a no-op for every current caller, and moving it inside `groupFlowIntoCycles` is safe. The divergence is pinned by a test rather than resolved silently:

```
✓ does not let a zero-flow day bridge two cycles
✓ ignores days with no flow recorded at all
```

## The third algorithm, and the number users will see change

`CyclePrediction.tsx:84-114` counted cycles by pure gap detection, never consulting the markers. Replacing it with the shared count **changes the number shown in settings and can flip the gate**. Both directions are real and both are tested:

| Data | Old count | New count |
| --- | --- | --- |
| Six consecutive flow days, `is_cycle_start` on day 4 | 1 — predictions off | 2 — predictions on |
| Three consecutive flow days, `is_cycle_start` on day 2 | 1 — predictions on | 0 — predictions off |

The second row is the one worth your attention: `CyclePrediction.tsx` does not just display the count, it **auto-disables predictions and writes a setting** when the count is short. A user who marked a cycle start part-way through a short run can have predictions switch themselves off on next open. That is the correct answer under the marker-honouring definition — their marked cycles genuinely are too short — but it is a visible change, not a silent one.

## Time is a parameter

`calculateConfidence`'s `referenceDate` defaulted to `new Date()`, and `generatePredictions`'s was optional. Both are now required, per the plan. `useCyclePhase` takes a `referenceDay`, and both callers pass `useMemo(() => startOfLocalDay(), [])` — the same pattern `app/(pregnancy-tabs)/index.tsx` already uses.

**The existing test file needed exactly one edit**: adding the now-required argument at two call sites. Nothing in `__tests__/cyclePredictionLogic.test.ts` had its expectations changed, which is the evidence that the unification preserved the definition that was already trusted.

## A third behaviour change I did not go looking for

`useCyclePhase`'s `cycleState` memo computed "today" as `new Date().toISOString().split("T")[0]` — **UTC** — then compared it against local date strings from the database to decide whether the user is currently bleeding. West of UTC, after mid-afternoon, that asks about tomorrow, finds nothing, and fails to override the phase to menstrual. Same class of bug as the DST one in #199, in code this PR moves. It now formats locally.

## `utils/dates.ts`

The cycle module needs local date formatting. Importing `formatAsISODate` from `utils/pregnancyDates.ts` would be a cycle-mode module depending on a pregnancy-mode one, which ADR 0001 is explicitly about not doing. So the calendar-day primitives — `formatAsISODate`, `parseISODate`, `differenceInDays`, `addDays`, `startOfLocalDay` — move to `utils/dates.ts`, which belongs to neither mode. `utils/pregnancyDates.ts` keeps the gestational-age rules and imports them. Five files updated, one import path per name, no re-export shims.

This was not in the issue. The alternative was a fourth copy of "format a Date as a local YYYY-MM-DD", which is the thing this plan exists to stop.

## Also deduplicated

`calculateAverageCycleLength` and `calculateCycleVariation` each contained the same loop computing gaps between cycle starts. It is now `cycleLengthsBetween`, used by both.

## Verification

```
$ npx eslint . --max-warnings=0
ESLINT EXIT: 0

$ npm run typecheck
TSC EXIT: 0

$ TZ=UTC npm test -- --ci
Test Suites: 12 passed, 12 total
Tests:       163 passed, 163 total
JEST EXIT (UTC): 0

$ TZ=America/Los_Angeles npm test -- --ci
Tests:       163 passed, 163 total
JEST EXIT (LA): 0
```

The phase-mapping assertions promised in #194's description are re-expressed here against this module, with no mocks — `determinePhase` is tested directly rather than through a rendered screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)