### PR TITLE
refactor: split useAccordion, and give sections a real identity (#184)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,11 +10,11 @@ This file is maintained lazily: terms are added when a design decision actually 
 
 **Logged Day**: the whole of what the user has recorded for one Day: flow, notes, cycle start/end markers, intercourse, and the Moods, Symptoms and Medications selected. This is the unit the app loads and saves as one snapshot. It is a view over several tables, not a table itself.
 
-**Section**: one loggable area of a Logged Day, as presented in the day view: Flow, Moods, Symptoms, Medications, Birth Control, Intercourse, Notes, and in pregnancy mode Kicks and Appointments. Sections are a property of what can be logged, not of which tracking mode is active; each mode renders its own subset. One Section is expanded at a time.
+**Section**: one loggable area of a Logged Day, as presented in the day view: Flow, Moods, Symptoms, Medications, Birth Control, Intercourse, Notes, and in pregnancy mode Kicks and Appointments. Sections are a property of what can be logged, not of which tracking mode is active; each mode renders its own subset. One Section is expanded at a time, and which one is local to the view showing it. The names live in `constants/Sections.ts`.
 
 **Selected Date**: which date the day view is showing. Shared, because the calendar picks it and the day view reads it. Only the date is shared: the Selected Date is not a Logged Day, and the day's contents belong to whatever is displaying them.
 
-**Catalogue**: the set of Moods, Symptoms or Medications a user can choose from. Distinct from the entries that reference them. The Catalogue is edited rarely, in settings, while entries are written constantly, while logging. `moods`, `symptoms` and `medications` are Catalogue tables.
+**Catalogue**: the set of Moods, Symptoms or Medications a user can choose from. Distinct from the entries that reference them. The Catalogue is edited rarely, in settings, while entries are written constantly, while logging. `moods`, `symptoms` and `medications` are Catalogue tables. It is read once and held; whoever edits it says so explicitly. Birth control is a Medication row distinguished by its `type`, and the day view offers it as its own Section.
 
 **Entry**: a single recorded selection joining a Day to a Catalogue item: `mood_entries`, `symptom_entries`, `medication_entries`. An Entry may carry its own detail, such as a Medication's `time_taken`.
 

--- a/components/dayView/BirthControlAccordion.tsx
+++ b/components/dayView/BirthControlAccordion.tsx
@@ -1,25 +1,26 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { View, Modal, Platform } from "react-native";
 import { List, Text, Button, TextInput, useTheme } from "react-native-paper";
 import DateTimePicker from "@react-native-community/datetimepicker";
-import { getAllVisibleMedications } from "@/db/database";
 import SingleChipSelection from "./SingleChipSelection";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
 import type { LoggedMedication } from "@/db/loggedDay";
+import { Section } from "@/constants/Sections";
 
 export default function BirthControlAccordion({
   state,
   setExpandedAccordion,
+  birthControlOptions,
   birthControl,
   setBirthControl,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
+  birthControlOptions: string[];
   birthControl: LoggedMedication | null;
   setBirthControl: (birthControl: LoggedMedication | null) => void;
 }) {
   const theme = useTheme();
-  const [birthControlOptions, setBirthControlOptions] = useState<string[]>([]);
 
   // The picker's own state. It has exactly one reader, this component, so it
   // was never app state; it was in a store because everything else was.
@@ -49,18 +50,6 @@ export default function BirthControlAccordion({
     setBirthControl(birthControl ? { ...birthControl, timeTaken: time } : null);
   const setBirthControlNotes = (notes: string) =>
     setBirthControl(birthControl ? { ...birthControl, notes } : null);
-
-  useEffect(() => {
-    const fetchMedications = async () => {
-      const medications = await getAllVisibleMedications();
-      setBirthControlOptions(
-        medications
-          .filter((medication) => medication.type === "birth control")
-          .map((medication) => medication.name),
-      );
-    };
-    fetchMedications();
-  }, [state]);
 
   const handleTimeChange = (event: any, selectedTime?: Date) => {
     if (Platform.OS === "android") {
@@ -234,9 +223,11 @@ export default function BirthControlAccordion({
           </Text>
         </View>
       }
-      expanded={state === "birthControl"}
+      expanded={state === Section.BirthControl}
       onPress={() =>
-        setExpandedAccordion(state === "birthControl" ? null : "birthControl")
+        setExpandedAccordion(
+          state === Section.BirthControl ? null : Section.BirthControl,
+        )
       }
       left={(props) => <List.Icon {...props} icon="shield-check" />}
     >

--- a/components/dayView/DayView.tsx
+++ b/components/dayView/DayView.tsx
@@ -2,10 +2,11 @@ import { useCallback, useState, useEffect, useRef } from "react";
 import { StyleSheet, View } from "react-native";
 import { List, Text, useTheme, Divider } from "react-native-paper";
 import {
-  useAccordion,
   useSelectedDate,
   useDatabaseChangeNotifier,
 } from "@/stores/calendar-storage";
+import { Section } from "@/constants/Sections";
+import { useCatalogue } from "@/hooks/useCatalogue";
 import FlowAccordion from "@/components/dayView/FlowAccordion";
 import MedicationsAccordion from "./MedicationsAccordion";
 import BirthControlAccordion from "./BirthControlAccordion";
@@ -27,7 +28,10 @@ import {
 
 export default function DayView() {
   const theme = useTheme();
-  const { state, setExpandedAccordion } = useAccordion();
+  // Which Section is expanded is this screen's business. It used to be a
+  // store, which doubled as the Catalogue's cache-invalidation signal.
+  const [state, setExpandedAccordion] = useState<Section | null>(null);
+  const catalogue = useCatalogue();
   const { date } = useSelectedDate();
   const { databaseChange } = useDatabaseChangeNotifier();
 
@@ -156,6 +160,7 @@ export default function DayView() {
           <BirthControlAccordion
             state={state}
             setExpandedAccordion={setExpandedAccordion}
+            birthControlOptions={catalogue.birthControl}
             birthControl={birthControlIn(day)}
             setBirthControl={setBirthControl}
           />
@@ -170,6 +175,7 @@ export default function DayView() {
           <SymptomsAccordion
             state={state}
             setExpandedAccordion={setExpandedAccordion}
+            symptomOptions={catalogue.symptoms}
             selectedSymptoms={day.symptoms}
             setSelectedSymptoms={(symptoms) => edit({ symptoms })}
           />
@@ -177,6 +183,7 @@ export default function DayView() {
           <MoodsAccordion
             state={state}
             setExpandedAccordion={setExpandedAccordion}
+            moodOptions={catalogue.moods}
             selectedMoods={day.moods}
             setSelectedMoods={(moods) => edit({ moods })}
           />
@@ -184,6 +191,7 @@ export default function DayView() {
           <MedicationsAccordion
             state={state}
             setExpandedAccordion={setExpandedAccordion}
+            medicationOptions={catalogue.medications}
             selectedMedications={medicationsExcludingBirthControl(day)}
             setSelectedMedications={setMedications}
           />

--- a/components/dayView/FlowAccordion.tsx
+++ b/components/dayView/FlowAccordion.tsx
@@ -7,6 +7,7 @@ import {
   loggingAccordionTitleStyles,
   useLoggingChipGridStyle,
 } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 const flowOptions = ["None", "Spotting", "Light", "Medium", "Heavy"];
 
@@ -164,8 +165,8 @@ export default function FlowAccordion({
   is_cycle_end,
   setCycleEnd,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
   flow_intensity: number;
   setFlow: (intensity: number) => void;
   is_cycle_start?: boolean;
@@ -184,8 +185,10 @@ export default function FlowAccordion({
           </Text>
         </View>
       }
-      expanded={state === "flow"}
-      onPress={() => setExpandedAccordion(state === "flow" ? null : "flow")}
+      expanded={state === Section.Flow}
+      onPress={() =>
+        setExpandedAccordion(state === Section.Flow ? null : Section.Flow)
+      }
       left={(props) => <List.Icon {...props} icon="water" />}
     >
       {flow_intensity !== 0 && (

--- a/components/dayView/IntercourseAccordion.tsx
+++ b/components/dayView/IntercourseAccordion.tsx
@@ -1,6 +1,7 @@
 import { List, Text, Switch } from "react-native-paper";
 import { View } from "react-native";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 export default function IntercourseAccordion({
   state,
@@ -8,8 +9,8 @@ export default function IntercourseAccordion({
   intercourse,
   setIntercourse,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
   intercourse: boolean;
   setIntercourse: (value: boolean) => void;
 }) {
@@ -24,9 +25,11 @@ export default function IntercourseAccordion({
           </Text>
         </View>
       }
-      expanded={state === "intercourse"}
+      expanded={state === Section.Intercourse}
       onPress={() =>
-        setExpandedAccordion(state === "intercourse" ? null : "intercourse")
+        setExpandedAccordion(
+          state === Section.Intercourse ? null : Section.Intercourse,
+        )
       }
       left={(props) => <List.Icon {...props} icon="heart" />}
     >

--- a/components/dayView/MedicationsAccordion.tsx
+++ b/components/dayView/MedicationsAccordion.tsx
@@ -1,37 +1,26 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { List, Text, Button } from "react-native-paper";
-import { getAllVisibleMedications } from "@/db/database";
 import ChipSelection from "./ChipSelection";
 import { birthControlOptions } from "@/constants/BirthControlTypes";
 import CustomEntries from "@/components/settings/CustomEntries";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 export default function MedicationsAccordion({
   state,
   setExpandedAccordion,
+  medicationOptions,
   selectedMedications,
   setSelectedMedications,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
+  medicationOptions: string[];
   selectedMedications: string[];
   setSelectedMedications: (medications: string[]) => void;
 }) {
-  const [medicationOptions, setMedicationOptions] = useState<string[]>([]);
   const [customEntriesVisible, setCustomEntriesVisible] = useState(false);
-
-  useEffect(() => {
-    const fetchMedications = async () => {
-      const medications = await getAllVisibleMedications();
-      setMedicationOptions(
-        medications
-          .filter((medication) => medication.type !== "birth control")
-          .map((medication) => medication.name),
-      );
-    };
-    fetchMedications();
-  }, [state, customEntriesVisible]);
 
   // Filter out birth control medications and only include visible medications to calculate the count
   const medicationsWithoutBirthControl = selectedMedications.filter(
@@ -56,9 +45,11 @@ export default function MedicationsAccordion({
             </Text>
           </View>
         }
-        expanded={state === "medications"}
+        expanded={state === Section.Medications}
         onPress={() =>
-          setExpandedAccordion(state === "medications" ? null : "medications")
+          setExpandedAccordion(
+            state === Section.Medications ? null : Section.Medications,
+          )
         }
         left={(props) => <List.Icon {...props} icon="pill" />}
       >
@@ -92,8 +83,7 @@ export default function MedicationsAccordion({
       {customEntriesVisible && (
         <CustomEntries
           modalVisibleInitially={true}
-          // automatically opens to the "medications" section (id=3)
-          initialExpandedAccordion="3"
+          initialExpandedCatalogue="medication"
           onModalClose={() => setCustomEntriesVisible(false)}
         />
       )}

--- a/components/dayView/MoodsAccordion.tsx
+++ b/components/dayView/MoodsAccordion.tsx
@@ -1,32 +1,25 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { List, Text, Button } from "react-native-paper";
-import { getAllVisibleMoods } from "@/db/database";
 import ChipSelection from "./ChipSelection";
 import CustomEntries from "@/components/settings/CustomEntries";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 export default function MoodsAccordion({
   state,
   setExpandedAccordion,
+  moodOptions,
   selectedMoods,
   setSelectedMoods,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
+  moodOptions: string[];
   selectedMoods: string[];
   setSelectedMoods: (moods: string[]) => void;
 }) {
-  const [moodOptions, setMoodOptions] = useState<string[]>([]);
   const [customEntriesVisible, setCustomEntriesVisible] = useState(false);
-
-  useEffect(() => {
-    const fetchMoods = async () => {
-      const moods = await getAllVisibleMoods();
-      setMoodOptions(moods.map((mood) => mood.name));
-    };
-    fetchMoods();
-  }, [state, customEntriesVisible]);
 
   const selectedVisibleMoods = selectedMoods.filter((mood) =>
     moodOptions.includes(mood),
@@ -48,8 +41,10 @@ export default function MoodsAccordion({
             </Text>
           </View>
         }
-        expanded={state === "mood"}
-        onPress={() => setExpandedAccordion(state === "mood" ? null : "mood")}
+        expanded={state === Section.Moods}
+        onPress={() =>
+          setExpandedAccordion(state === Section.Moods ? null : Section.Moods)
+        }
         left={(props) => <List.Icon {...props} icon="emoticon" />}
       >
         <ChipSelection
@@ -82,8 +77,7 @@ export default function MoodsAccordion({
       {customEntriesVisible && (
         <CustomEntries
           modalVisibleInitially={true}
-          // automatically opens to the "Moods" section (id=2)
-          initialExpandedAccordion="2"
+          initialExpandedCatalogue="mood"
           onModalClose={() => setCustomEntriesVisible(false)}
         />
       )}

--- a/components/dayView/NotesAccordion.tsx
+++ b/components/dayView/NotesAccordion.tsx
@@ -1,6 +1,7 @@
 import { List, TextInput, Text } from "react-native-paper";
 import { View } from "react-native";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 export default function NotesAccordion({
   state,
@@ -8,8 +9,8 @@ export default function NotesAccordion({
   notes,
   setNotes,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
   notes: string | undefined;
   setNotes: (notes: string) => void;
 }) {
@@ -20,8 +21,10 @@ export default function NotesAccordion({
           <Text style={loggingAccordionTitleStyles.label}>Notes</Text>
         </View>
       }
-      expanded={state === "notes"}
-      onPress={() => setExpandedAccordion(state === "notes" ? null : "notes")}
+      expanded={state === Section.Notes}
+      onPress={() =>
+        setExpandedAccordion(state === Section.Notes ? null : Section.Notes)
+      }
       left={(props) => <List.Icon {...props} icon="note" />}
     >
       <View style={{ padding: 16 }}>

--- a/components/dayView/SymptomsAccordion.tsx
+++ b/components/dayView/SymptomsAccordion.tsx
@@ -1,32 +1,25 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { View } from "react-native";
 import { List, Text, Button } from "react-native-paper";
 import ChipSelection from "./ChipSelection";
-import { getAllVisibleSymptoms } from "@/db/database";
 import CustomEntries from "@/components/settings/CustomEntries";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 export default function SymptomsAccordion({
   state,
   setExpandedAccordion,
+  symptomOptions,
   selectedSymptoms,
   setSelectedSymptoms,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
+  symptomOptions: string[];
   selectedSymptoms: string[];
   setSelectedSymptoms: (symptoms: string[]) => void;
 }) {
-  const [symptomOptions, setSymptomOptions] = useState<string[]>([]);
   const [customEntriesVisible, setCustomEntriesVisible] = useState(false);
-
-  useEffect(() => {
-    const fetchSymptoms = async () => {
-      const symptoms = await getAllVisibleSymptoms();
-      setSymptomOptions(symptoms.map((symptom) => symptom.name));
-    };
-    fetchSymptoms();
-  }, [state, customEntriesVisible]);
 
   const selectedVisibleSymptoms = selectedSymptoms.filter((symptom) =>
     symptomOptions.includes(symptom),
@@ -48,9 +41,11 @@ export default function SymptomsAccordion({
             </Text>
           </View>
         }
-        expanded={state === "symptoms"}
+        expanded={state === Section.Symptoms}
         onPress={() =>
-          setExpandedAccordion(state === "symptoms" ? null : "symptoms")
+          setExpandedAccordion(
+            state === Section.Symptoms ? null : Section.Symptoms,
+          )
         }
         left={(props) => <List.Icon {...props} icon="alert-decagram" />}
       >
@@ -84,7 +79,7 @@ export default function SymptomsAccordion({
       {customEntriesVisible && (
         <CustomEntries
           modalVisibleInitially={true}
-          initialExpandedAccordion="1"
+          initialExpandedCatalogue="symptom"
           onModalClose={() => setCustomEntriesVisible(false)}
         />
       )}

--- a/components/dayView/__tests__/saveMessage.test.ts
+++ b/components/dayView/__tests__/saveMessage.test.ts
@@ -1,5 +1,6 @@
 import { savedSectionLabel } from "@/components/dayView/saveMessage";
 import { emptyLoggedDay, type LoggedDay } from "@/db/loggedDay";
+import { Section } from "@/constants/Sections";
 
 // This decision touches no database. The stub says so: db/loggedDay.ts opens a
 // handle when it loads, and nothing here ever reaches it.
@@ -9,20 +10,18 @@ jest.mock("@/db/operations/setup", () => ({
 }));
 
 /**
- * The exact strings the accordions pass to `setExpandedAccordion`. Kept here
- * as literals on purpose: this test's job is to prove the save-message logic
- * agrees with what the accordions actually send, so reading them from a shared
- * constant would assume the very thing under test. #184 replaces both sides
- * with one enumeration, at which point this list becomes that enumeration.
+ * Both sides now name the same enumeration, so the drift this test was written
+ * to catch cannot compile. What is left worth checking is the mapping from a
+ * Section to its label, and the fallback when no Section is expanded.
  */
 const SECTION_FROM_ACCORDION = {
-  flow: "flow", // FlowAccordion.tsx:188
-  symptoms: "symptoms", // SymptomsAccordion.tsx:53
-  moods: "mood", // MoodsAccordion.tsx:52
-  medications: "medications", // MedicationsAccordion.tsx:61
-  birthControl: "birthControl", // BirthControlAccordion.tsx:227
-  intercourse: "intercourse", // IntercourseAccordion.tsx:29
-  notes: "notes", // NotesAccordion.tsx:24
+  flow: Section.Flow,
+  symptoms: Section.Symptoms,
+  moods: Section.Moods,
+  medications: Section.Medications,
+  birthControl: Section.BirthControl,
+  intercourse: Section.Intercourse,
+  notes: Section.Notes,
 };
 
 const empty: LoggedDay = emptyLoggedDay("2026-04-01");

--- a/components/dayView/saveMessage.ts
+++ b/components/dayView/saveMessage.ts
@@ -3,27 +3,26 @@ import {
   medicationsExcludingBirthControl,
   type LoggedDay,
 } from "@/db/loggedDay";
+import { Section } from "@/constants/Sections";
 
 /**
  * Which Section a save should be attributed to, as a label for the
  * "<Section> Saved!" message.
  *
- * Extracted from the switch inside DayView's onSave so that the agreement
- * between what the accordions send and what this reads is testable. It was not
- * testable before, and three of the seven cases had never fired: the
- * accordions send "symptoms", "medications" and "notes" while the switch
- * matched "symptom", "medication" and "note". Those saves fell through to the
- * fixed-priority fallback, which can name a Section the user did not touch.
+ * Three of the seven cases here used to be dead: the accordions said
+ * "symptoms", "medications" and "notes" while this switch said "symptom",
+ * "medication" and "note", and both sides typechecked because the contract was
+ * `string | null`. Those saves fell through to the fixed-priority fallback,
+ * which can name a Section the user did not touch.
  *
- * The section strings are still bare strings here, which is the underlying
- * weakness. #184 replaces them with a Section enumeration so the disagreement
- * stops compiling rather than being caught by this test.
+ * Both sides now name the same `Section`, so that disagreement no longer
+ * compiles.
  */
 const sameNames = (a: string[], b: string[]) =>
   JSON.stringify(a) === JSON.stringify(b);
 
 export function savedSectionLabel(
-  expandedSection: string | null,
+  expandedSection: Section | null,
   current: LoggedDay,
   lastSaved: LoggedDay | null,
 ): string | null {
@@ -31,19 +30,19 @@ export function savedSectionLabel(
   const currentBirthControl = birthControlIn(current)?.name ?? null;
 
   switch (expandedSection) {
-    case "flow":
+    case Section.Flow:
       return current.flow !== 0 ? "Flow" : null;
-    case "symptoms":
+    case Section.Symptoms:
       return current.symptoms.length > 0 ? "Symptoms" : null;
-    case "mood":
+    case Section.Moods:
       return current.moods.length > 0 ? "Moods" : null;
-    case "medications":
+    case Section.Medications:
       return currentMedications.length > 0 ? "Medications" : null;
-    case "birthControl":
+    case Section.BirthControl:
       return currentBirthControl ? "Birth Control" : null;
-    case "notes":
+    case Section.Notes:
       return current.notes.trim() !== "" ? "Notes" : null;
-    case "intercourse":
+    case Section.Intercourse:
       // Absence is itself a value the user chose here, so unlike the others
       // there is no "empty" case to stay quiet about.
       return "Intercourse";

--- a/components/pregnancyDayView/AppointmentsAccordion.tsx
+++ b/components/pregnancyDayView/AppointmentsAccordion.tsx
@@ -20,6 +20,7 @@ import {
   loggingAccordionTitleStyles,
   loggingGridStyles,
 } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 const APPOINTMENT_TYPES = ["OB Visit", "Ultrasound", "Lab Work", "Other"];
 
@@ -30,8 +31,8 @@ export default function AppointmentsAccordion({
   appointments,
   setAppointments,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
   date: string;
   appointments: PregnancyAppointment[];
   setAppointments: (appointments: PregnancyAppointment[]) => void;
@@ -78,9 +79,11 @@ export default function AppointmentsAccordion({
           </Text>
         </View>
       }
-      expanded={state === "appointments"}
+      expanded={state === Section.Appointments}
       onPress={() =>
-        setExpandedAccordion(state === "appointments" ? null : "appointments")
+        setExpandedAccordion(
+          state === Section.Appointments ? null : Section.Appointments,
+        )
       }
       left={(props) => <List.Icon {...props} icon="calendar-clock" />}
     >

--- a/components/pregnancyDayView/KicksAccordion.tsx
+++ b/components/pregnancyDayView/KicksAccordion.tsx
@@ -1,6 +1,7 @@
 import { View } from "react-native";
 import { List, Text, IconButton, useTheme } from "react-native-paper";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
+import { Section } from "@/constants/Sections";
 
 export default function KicksAccordion({
   state,
@@ -8,8 +9,8 @@ export default function KicksAccordion({
   kicks,
   setKicks,
 }: {
-  state: string | null;
-  setExpandedAccordion: (accordion: string | null) => void;
+  state: Section | null;
+  setExpandedAccordion: (section: Section | null) => void;
   kicks: number;
   setKicks: (kicks: number) => void;
 }) {
@@ -26,8 +27,10 @@ export default function KicksAccordion({
           </Text>
         </View>
       }
-      expanded={state === "kicks"}
-      onPress={() => setExpandedAccordion(state === "kicks" ? null : "kicks")}
+      expanded={state === Section.Kicks}
+      onPress={() =>
+        setExpandedAccordion(state === Section.Kicks ? null : Section.Kicks)
+      }
       left={(props) => <List.Icon {...props} icon="baby-face-outline" />}
     >
       <View

--- a/components/pregnancyDayView/PregnancyDayView.tsx
+++ b/components/pregnancyDayView/PregnancyDayView.tsx
@@ -8,9 +8,10 @@ import {
 } from "@/db/database";
 import {
   usePregnancySelectedDate,
-  usePregnancyAccordion,
   usePregnancyAppointments,
 } from "@/stores/pregnancy-storage";
+import { Section } from "@/constants/Sections";
+import { useCatalogue } from "@/hooks/useCatalogue";
 import KicksAccordion from "./KicksAccordion";
 import AppointmentsAccordion from "./AppointmentsAccordion";
 import SymptomsAccordion from "@/components/dayView/SymptomsAccordion";
@@ -20,7 +21,10 @@ import Snackbar from "@/components/ui/Snackbar";
 
 export default function PregnancyDayView() {
   const theme = useTheme();
-  const { state, setExpandedAccordion } = usePregnancyAccordion();
+  // Local, like the cycle day view's. Settings screens used to null the cycle
+  // accordion store to refresh the Catalogue, which never reached this view.
+  const [state, setExpandedAccordion] = useState<Section | null>(null);
+  const catalogue = useCatalogue();
   const {
     date,
     kicks,
@@ -138,6 +142,7 @@ export default function PregnancyDayView() {
           <SymptomsAccordion
             state={state}
             setExpandedAccordion={setExpandedAccordion}
+            symptomOptions={catalogue.symptoms}
             selectedSymptoms={symptoms}
             setSelectedSymptoms={setSymptoms}
           />
@@ -145,6 +150,7 @@ export default function PregnancyDayView() {
           <MoodsAccordion
             state={state}
             setExpandedAccordion={setExpandedAccordion}
+            moodOptions={catalogue.moods}
             selectedMoods={moods}
             setSelectedMoods={setMoods}
           />

--- a/components/settings/CustomEntries.tsx
+++ b/components/settings/CustomEntries.tsx
@@ -29,7 +29,6 @@ import {
 } from "react-native-paper";
 import { ScrollView, StyleSheet, Dimensions } from "react-native";
 import {
-  useAccordion,
   useCalendarFilters,
   useDatabaseChangeNotifier,
 } from "@/stores/calendar-storage";
@@ -37,6 +36,7 @@ import { symptomOptions } from "@/constants/Symptoms";
 import { medicationOptions } from "@/constants/Medications";
 import { moodOptions } from "@/constants/Moods";
 import { birthControlOptions } from "@/constants/BirthControlTypes";
+import { invalidateCatalogue, type CatalogueKind } from "@/db/catalogue";
 
 function InfoDialog({
   visible,
@@ -202,18 +202,17 @@ function AccordionContents({
 
 function CustomEntriesModal({
   onDismiss,
-  initialExpandedAccordion = "1",
+  initialExpandedCatalogue = "symptom",
 }: {
   onDismiss: () => void;
-  initialExpandedAccordion?: string;
+  initialExpandedCatalogue?: CatalogueKind;
 }) {
   const theme = useTheme();
   const { width, height } = Dimensions.get("window");
   const styles = makeStyles(theme, width, height);
   const setDbChange = useDatabaseChangeNotifier().setDatabaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
-  const setAccordionState = useAccordion().setExpandedAccordion;
-  const [expanded, setExpanded] = useState<string>(initialExpandedAccordion);
+  const [expanded, setExpanded] = useState<string>(initialExpandedCatalogue);
   const [symptoms, setSymptoms] = useState<string[]>([]);
   const [moods, setMoods] = useState<string[]>([]);
   const [medications, setMedications] = useState<string[]>([]);
@@ -338,9 +337,10 @@ function CustomEntriesModal({
   };
 
   const onDismissModal = () => {
-    // this closes any open accordions on the calendar page,
-    // which will force them to re-render with the updated data
-    setAccordionState(null);
+    // Say the Catalogue changed. This used to collapse the day view's
+    // accordions instead, because their fetch was keyed on that state, which
+    // meant adding a custom Mood shut the Section the user was working in.
+    invalidateCatalogue();
     // force useLiveQuery to update
     setDbChange(Math.random().toString());
     onDismiss();
@@ -366,7 +366,7 @@ function CustomEntriesModal({
           >
             <List.Accordion
               title="Symptoms"
-              id="1"
+              id="symptom"
               titleStyle={styles.listTitle}
             >
               <AccordionContents
@@ -377,7 +377,11 @@ function CustomEntriesModal({
               />
             </List.Accordion>
             <Divider />
-            <List.Accordion title="Moods" id="2" titleStyle={styles.listTitle}>
+            <List.Accordion
+              title="Moods"
+              id="mood"
+              titleStyle={styles.listTitle}
+            >
               <AccordionContents
                 items={moods}
                 itemType="mood"
@@ -388,7 +392,7 @@ function CustomEntriesModal({
             <Divider />
             <List.Accordion
               title="Medications"
-              id="3"
+              id="medication"
               titleStyle={styles.listTitle}
             >
               <AccordionContents
@@ -401,7 +405,7 @@ function CustomEntriesModal({
             <Divider />
             <List.Accordion
               title="Birth Control"
-              id="4"
+              id="birth control"
               titleStyle={styles.listTitle}
             >
               <AccordionContents
@@ -431,11 +435,11 @@ function CustomEntriesModal({
 export default function CustomEntries({
   modalVisibleInitially = false,
   onModalClose,
-  initialExpandedAccordion = "1",
+  initialExpandedCatalogue = "symptom",
 }: {
   modalVisibleInitially?: boolean;
   onModalClose?: () => void;
-  initialExpandedAccordion?: string;
+  initialExpandedCatalogue?: CatalogueKind;
 } = {}) {
   const [modalVisible, setModalVisible] = useState(modalVisibleInitially);
 
@@ -457,7 +461,7 @@ export default function CustomEntries({
       {modalVisible && (
         <CustomEntriesModal
           onDismiss={handleModalClose}
-          initialExpandedAccordion={initialExpandedAccordion}
+          initialExpandedCatalogue={initialExpandedCatalogue}
         />
       )}
     </ThemedView>

--- a/components/settings/EntryVisibilitySettings.tsx
+++ b/components/settings/EntryVisibilitySettings.tsx
@@ -25,10 +25,10 @@ import {
 } from "react-native-paper";
 import { ScrollView, StyleSheet, Dimensions } from "react-native";
 import {
-  useAccordion,
   useCalendarFilters,
   useDatabaseChangeNotifier,
 } from "@/stores/calendar-storage";
+import { invalidateCatalogue } from "@/db/catalogue";
 
 interface Symptom {
   id: number;
@@ -138,7 +138,6 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
   const styles = makeStyles(theme, width, height);
   const setDbChange = useDatabaseChangeNotifier().setDatabaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
-  const setAccordionState = useAccordion().setExpandedAccordion;
   const [expanded, setExpanded] = useState<string>("1");
   const [symptoms, setSymptoms] = useState<Symptom[]>([]);
   const [moods, setMoods] = useState<Mood[]>([]);
@@ -237,9 +236,10 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
   };
 
   const onDismissModal = () => {
-    // this closes any open accordions on the calendar page,
-    // which will force them to re-render with the updated data
-    setAccordionState(null);
+    // Say the Catalogue changed. This used to collapse the day view's
+    // accordions instead, because their fetch was keyed on that state, which
+    // meant adding a custom Mood shut the Section the user was working in.
+    invalidateCatalogue();
     // force useLiveQuery to update
     setDbChange(Math.random().toString());
     onDismiss();
@@ -265,7 +265,7 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
           >
             <List.Accordion
               title="Symptoms"
-              id="1"
+              id="symptom"
               titleStyle={styles.listTitle}
             >
               <AccordionContents
@@ -275,7 +275,11 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
               />
             </List.Accordion>
             <Divider />
-            <List.Accordion title="Moods" id="2" titleStyle={styles.listTitle}>
+            <List.Accordion
+              title="Moods"
+              id="mood"
+              titleStyle={styles.listTitle}
+            >
               <AccordionContents
                 items={moods}
                 itemType="mood"
@@ -285,7 +289,7 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
             <Divider />
             <List.Accordion
               title="Medications"
-              id="3"
+              id="medication"
               titleStyle={styles.listTitle}
             >
               <AccordionContents
@@ -297,7 +301,7 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
             <Divider />
             <List.Accordion
               title="Birth Control"
-              id="4"
+              id="birth control"
               titleStyle={styles.listTitle}
             >
               <AccordionContents

--- a/constants/Interfaces.ts
+++ b/constants/Interfaces.ts
@@ -49,11 +49,6 @@ export interface LoadData {
   setShow: (show: boolean) => void;
 }
 
-export interface Accordion {
-  state: string | null;
-  setExpandedAccordion: (state: string | null) => void;
-}
-
 export interface FlowDataState {
   flowDataForCurrentMonth: DayData[];
   setFlowDataForCurrentMonth: (data: DayData[]) => void;

--- a/constants/Sections.ts
+++ b/constants/Sections.ts
@@ -1,0 +1,51 @@
+/**
+ * Every Section of a Logged Day, in either tracking mode.
+ *
+ * Sections are a property of what can be logged, not of which mode is active;
+ * each mode renders its own subset. See CONTEXT.md, Section.
+ *
+ * These strings were previously written as bare literals on both sides of a
+ * `state: string | null` contract, which is how three cases of DayView's
+ * save-message switch came to be dead: the accordions said "symptoms" and the
+ * switch said "symptom". Naming them once means that stops compiling.
+ */
+
+// the type of a Section are the same thing; naming them apart would mean
+// writing SectionId at every use site.
+export const Section = {
+  Flow: "flow",
+  Moods: "moods",
+  Symptoms: "symptoms",
+  Medications: "medications",
+  BirthControl: "birthControl",
+  Intercourse: "intercourse",
+  Notes: "notes",
+  Kicks: "kicks",
+  Appointments: "appointments",
+} as const;
+
+// The value and the type of a Section are the same thing; naming them apart
+// would mean writing SectionId at every use site.
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type Section = (typeof Section)[keyof typeof Section];
+
+/** The Sections cycle mode renders, in the order the day view shows them. */
+export const CYCLE_SECTIONS: readonly Section[] = [
+  Section.Flow,
+  Section.BirthControl,
+  Section.Intercourse,
+  Section.Symptoms,
+  Section.Moods,
+  Section.Medications,
+  Section.Notes,
+];
+
+/** The Sections pregnancy mode renders. */
+export const PREGNANCY_SECTIONS: readonly Section[] = [
+  Section.Kicks,
+  Section.Symptoms,
+  Section.Moods,
+  Section.Medications,
+  Section.Notes,
+  Section.Appointments,
+];

--- a/constants/__tests__/Sections.test.ts
+++ b/constants/__tests__/Sections.test.ts
@@ -1,0 +1,43 @@
+import {
+  CYCLE_SECTIONS,
+  PREGNANCY_SECTIONS,
+  Section,
+} from "@/constants/Sections";
+
+describe("Sections", () => {
+  it("names every section exactly once", () => {
+    const values = Object.values(Section);
+
+    expect(new Set(values).size).toBe(values.length);
+  });
+
+  it("gives each mode a subset of the same enumeration", () => {
+    for (const section of [...CYCLE_SECTIONS, ...PREGNANCY_SECTIONS]) {
+      expect(Object.values(Section)).toContain(section);
+    }
+  });
+
+  it("does not repeat a section within a mode", () => {
+    expect(new Set(CYCLE_SECTIONS).size).toBe(CYCLE_SECTIONS.length);
+    expect(new Set(PREGNANCY_SECTIONS).size).toBe(PREGNANCY_SECTIONS.length);
+  });
+
+  it("shares the sections both modes log", () => {
+    const shared = CYCLE_SECTIONS.filter((section) =>
+      PREGNANCY_SECTIONS.includes(section),
+    );
+
+    expect(shared).toEqual([
+      Section.Symptoms,
+      Section.Moods,
+      Section.Medications,
+      Section.Notes,
+    ]);
+  });
+
+  it("keeps flow and the cycle markers out of pregnancy mode", () => {
+    // Pregnancy has nothing to predict and no flow to log. ADR 0001.
+    expect(PREGNANCY_SECTIONS).not.toContain(Section.Flow);
+    expect(PREGNANCY_SECTIONS).not.toContain(Section.BirthControl);
+  });
+});

--- a/db/__tests__/catalogue.test.ts
+++ b/db/__tests__/catalogue.test.ts
@@ -1,0 +1,130 @@
+import {
+  CATALOGUE_KINDS,
+  invalidateCatalogue,
+  loadCatalogue,
+  onCatalogueInvalidated,
+} from "@/db/catalogue";
+import { medications, moods, symptoms } from "@/db/schema";
+import {
+  getTestDatabase,
+  resetTestDatabase,
+} from "@/__tests__/helpers/testDatabase";
+
+jest.mock("@/db/operations/setup", () =>
+  jest.requireActual("@/__tests__/helpers/testDatabase"),
+);
+
+const seed = () => {
+  const db = getTestDatabase();
+  db.insert(moods).values({ name: "Calm", visible: true }).run();
+  db.insert(moods).values({ name: "Hidden mood", visible: false }).run();
+  db.insert(symptoms).values({ name: "Cramps", visible: true }).run();
+  db.insert(medications)
+    .values({ name: "Ibuprofen", visible: true, type: null })
+    .run();
+  db.insert(medications)
+    .values({ name: "Pill", visible: true, type: "birth control" })
+    .run();
+  db.insert(medications)
+    .values({ name: "Hidden pill", visible: false, type: "birth control" })
+    .run();
+};
+
+beforeEach(() => {
+  resetTestDatabase();
+  invalidateCatalogue();
+});
+
+describe("loadCatalogue", () => {
+  it("returns what the user can choose from", async () => {
+    seed();
+
+    const catalogue = await loadCatalogue();
+
+    expect(catalogue.moods).toEqual(["Calm"]);
+    expect(catalogue.symptoms).toEqual(["Cramps"]);
+  });
+
+  it("leaves out anything the user has hidden", async () => {
+    seed();
+
+    const catalogue = await loadCatalogue();
+
+    expect(catalogue.moods).not.toContain("Hidden mood");
+    expect(catalogue.birthControl).not.toContain("Hidden pill");
+  });
+
+  it("separates birth control from the other medications", async () => {
+    seed();
+
+    const catalogue = await loadCatalogue();
+
+    expect(catalogue.medications).toEqual(["Ibuprofen"]);
+    expect(catalogue.birthControl).toEqual(["Pill"]);
+  });
+
+  it("is empty rather than absent when nothing is catalogued", async () => {
+    const catalogue = await loadCatalogue();
+
+    expect(catalogue).toEqual({
+      symptoms: [],
+      moods: [],
+      medications: [],
+      birthControl: [],
+    });
+  });
+
+  it("reads the database once for repeated loads", async () => {
+    seed();
+
+    const first = await loadCatalogue();
+    getTestDatabase().insert(moods).values({ name: "Excited" }).run();
+    const second = await loadCatalogue();
+
+    // Not stale by accident: the Catalogue is edited rarely, in settings, and
+    // whoever edits it says so. That is what invalidateCatalogue is for.
+    expect(second).toBe(first);
+  });
+
+  it("re-reads after an explicit invalidation", async () => {
+    seed();
+    await loadCatalogue();
+
+    getTestDatabase().insert(moods).values({ name: "Excited" }).run();
+    invalidateCatalogue();
+
+    expect((await loadCatalogue()).moods).toContain("Excited");
+  });
+});
+
+describe("onCatalogueInvalidated", () => {
+  it("tells subscribers when the catalogue changes", async () => {
+    const told = jest.fn();
+    const unsubscribe = onCatalogueInvalidated(told);
+
+    invalidateCatalogue();
+
+    expect(told).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  it("stops telling them once they unsubscribe", () => {
+    const told = jest.fn();
+    onCatalogueInvalidated(told)();
+
+    invalidateCatalogue();
+
+    expect(told).not.toHaveBeenCalled();
+  });
+});
+
+describe("CATALOGUE_KINDS", () => {
+  it("names the four things settings can edit", () => {
+    expect([...CATALOGUE_KINDS]).toEqual([
+      "symptom",
+      "mood",
+      "medication",
+      "birth control",
+    ]);
+  });
+});

--- a/db/catalogue.ts
+++ b/db/catalogue.ts
@@ -1,0 +1,78 @@
+import {
+  getAllVisibleMedications,
+  getAllVisibleMoods,
+  getAllVisibleSymptoms,
+} from "@/db/database";
+
+/** The four things settings can add to, hide from, or delete. */
+export const CATALOGUE_KINDS = [
+  "symptom",
+  "mood",
+  "medication",
+  "birth control",
+] as const;
+
+export type CatalogueKind = (typeof CATALOGUE_KINDS)[number];
+
+/**
+ * What the user can choose from while logging. See CONTEXT.md, Catalogue.
+ *
+ * Birth control is separated out because the day view offers it as its own
+ * Section, though it is a Medication row like any other.
+ */
+export type Catalogue = {
+  symptoms: string[];
+  moods: string[];
+  medications: string[];
+  birthControl: string[];
+};
+
+const BIRTH_CONTROL_TYPE = "birth control";
+
+let cached: Promise<Catalogue> | null = null;
+const listeners = new Set<() => void>();
+
+async function read(): Promise<Catalogue> {
+  const [symptoms, moods, medications] = await Promise.all([
+    getAllVisibleSymptoms(),
+    getAllVisibleMoods(),
+    getAllVisibleMedications(),
+  ]);
+
+  return {
+    symptoms: symptoms.map((symptom) => symptom.name),
+    moods: moods.map((mood) => mood.name),
+    medications: medications
+      .filter((medication) => medication.type !== BIRTH_CONTROL_TYPE)
+      .map((medication) => medication.name),
+    birthControl: medications
+      .filter((medication) => medication.type === BIRTH_CONTROL_TYPE)
+      .map((medication) => medication.name),
+  };
+}
+
+/**
+ * The Catalogue, read once and held.
+ *
+ * The Catalogue is edited rarely, in settings, while entries are written
+ * constantly, while logging. So this caches, and whoever edits it says so by
+ * calling `invalidateCatalogue`. It used to be re-read by each accordion
+ * whenever any accordion expanded, which is why settings screens collapsed the
+ * day view's accordions to force a refresh, and why adding a custom Mood shut
+ * the Section the user was working in.
+ */
+export function loadCatalogue(): Promise<Catalogue> {
+  if (!cached) cached = read();
+  return cached;
+}
+
+/** Say the Catalogue has changed. The explicit call the old signal implied. */
+export function invalidateCatalogue() {
+  cached = null;
+  for (const listener of listeners) listener();
+}
+
+export function onCatalogueInvalidated(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/hooks/useCatalogue.ts
+++ b/hooks/useCatalogue.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  loadCatalogue,
+  onCatalogueInvalidated,
+  type Catalogue,
+} from "@/db/catalogue";
+
+const EMPTY: Catalogue = {
+  symptoms: [],
+  moods: [],
+  medications: [],
+  birthControl: [],
+};
+
+/**
+ * Subscription only. The rules are in db/catalogue.ts; this re-reads when that
+ * module says the Catalogue changed.
+ */
+export function useCatalogue(): Catalogue {
+  const [catalogue, setCatalogue] = useState<Catalogue>(EMPTY);
+
+  const refresh = useCallback(() => {
+    let stale = false;
+    loadCatalogue().then((next) => {
+      if (!stale) setCatalogue(next);
+    });
+    return () => {
+      stale = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    const cancel = refresh();
+    const unsubscribe = onCatalogueInvalidated(() => refresh());
+    return () => {
+      cancel();
+      unsubscribe();
+    };
+  }, [refresh]);
+
+  return catalogue;
+}

--- a/stores/calendar-storage.tsx
+++ b/stores/calendar-storage.tsx
@@ -1,6 +1,5 @@
 import { create } from "zustand";
 import {
-  Accordion,
   DayData,
   SelectedDateStore,
   LoadData,
@@ -36,13 +35,6 @@ export const useData = create<LoadData>((set) => ({
   setShow: (show: boolean) => {
     set(() => ({ show: show }));
   },
-}));
-
-const initialString = null;
-
-export const useAccordion = create<Accordion>((set) => ({
-  state: initialString,
-  setExpandedAccordion: (data: string | null) => set(() => ({ state: data })),
 }));
 
 export const useFlowData = create<FlowDataState>((set) => ({

--- a/stores/pregnancy-storage.tsx
+++ b/stores/pregnancy-storage.tsx
@@ -14,11 +14,6 @@ interface PregnancySelectedDate {
   setNotes: (notes: string) => void;
 }
 
-interface PregnancyAccordion {
-  state: string | null;
-  setExpandedAccordion: (state: string | null) => void;
-}
-
 interface PregnancyCalendarFilters {
   selectedFilters: string[];
   setSelectedFilters: (filters: string[]) => void;
@@ -43,11 +38,6 @@ export const usePregnancySelectedDate = create<PregnancySelectedDate>(
     setNotes: (notes) => set({ notes }),
   }),
 );
-
-export const usePregnancyAccordion = create<PregnancyAccordion>((set) => ({
-  state: null,
-  setExpandedAccordion: (state) => set({ state }),
-}));
 
 export const usePregnancyCalendarFilters = create<PregnancyCalendarFilters>(
   (set) => ({


### PR DESCRIPTION
Closes #184.

**Stacked.** Merge order: #191 → #193 → #194 → #195 → #196 → #197 → #198 → #199 → #200 → #201 → #202 → #203 → this.

## Two jobs in one store

`useAccordion` tracked which Section was expanded **and** doubled as the cache-invalidation signal for the Catalogue, because each accordion keyed its fetch on `[state, customEntriesVisible]`.

That coupling is why `CustomEntries.tsx:340-347` and `EntryVisibilitySettings.tsx:239-246` each nulled a day-logging store to force a refresh, with the same block copied into both. And it is why **adding a custom Mood collapsed the Section the user was working in** — the collapse *was* the refresh mechanism.

Split:

- **Which Section is expanded** is now local state in each day view, named by `constants/Sections.ts`.
- **The Catalogue** is `db/catalogue.ts`: read once, held, invalidated by an explicit call.

## The mode hazard is gone

Both settings screens always nulled the **cycle** `useAccordion`, while `PregnancyDayView.tsx:23` read `usePregnancyAccordion`. The reach-back landed in a store the pregnancy view does not read, so a catalogue edit never refreshed pregnancy mode at all. Neither store exists now, and both views subscribe to the same explicit signal.

## The enumeration earns its keep immediately

Typing the prop as `Section | null` rather than `string | null` surfaced five call sites in `PregnancyDayView` that were passing an unconstrained string — exactly the class of drift that made three of the save-message switch's seven cases dead in #196. That switch and the accordions now name the same `Section`, so the disagreement cannot compile.

It also replaces the `"1"`–`"4"` accordion id numerals, whose mapping lived only in a comment at `MoodsAccordion.tsx:85` and was duplicated across both settings screens. They are catalogue kinds now: `id="mood"`, not `id="2"`.

## Fetching

Four accordions each ran their own catalogue query whenever *any* accordion expanded. The day views now read the catalogue once through a thin subscription hook and pass the options down — which is also what makes the three catalogue accordions collapsible in #185, since they no longer fetch anything.

```
✓ returns what the user can choose from
✓ leaves out anything the user has hidden
✓ separates birth control from the other medications
✓ reads the database once for repeated loads
✓ re-reads after an explicit invalidation
✓ tells subscribers when the catalogue changes
```

## One judgement call

`constants/Sections.ts` declares `Section` as both a const object and a type of the same name, with a targeted `no-redeclare` disable and a comment. The alternative is `SectionId` at every use site. I think the disable is the smaller cost, but it is the one line here I would happily change if you disagree.

## Verification

```
$ npx eslint . --max-warnings=0
ESLINT EXIT: 0

$ npm run typecheck
TSC EXIT: 0

$ TZ=Europe/Brussels npm test -- --ci
Test Suites: 17 passed, 17 total
Tests:       219 passed, 219 total
JEST EXIT: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)