### PR TITLE
docs: say plainly that docs/ is two things

### DIFF
--- a/PROJECTSTRUCTURE.md
+++ b/PROJECTSTRUCTURE.md
@@ -9,13 +9,23 @@ This document provides an overview of the project structure and key components o
 ├── app/                      # Holds the app entry point, screens, and navigation
 ├── assets/                   # Images, fonts, videos, icons, etc.
 ├── components/               # Components grouped by feature/screen/usage
-├── constants/                # App-wide constants (colors, fonts, etc.)
-├── constants/                # Constants (colors, TS interfaces, etc.)
+├── constants/                # App-wide constants (colors, TS interfaces, etc.)
 ├── db/                       # Drizzle database schema and operations
-├── docs/                     # Astro web page
+├── docs/                     # Two things: the Astro web page, and the documentation root
 ├── drizzle/                  # auto-generated Drizzle ORM files
 └── hooks/                    # Custom React hooks
 ```
+
+### `docs/` is both the marketing site and the documentation root
+
+Two unrelated things share that directory, and the name says only one of them. Which half something belongs to:
+
+- **The Astro site that publishes to the web**: `docs/astro.config.mjs`, `docs/src/`, `docs/public/`, `docs/tailwind.config.mjs`, `docs/dist/`, and its own `package.json` and `node_modules/`. Astro builds only `docs/src/pages` and `docs/public`, so the markdown below is invisible to it.
+- **The repo's documentation root**: `docs/adr/`, `docs/agents/`, `docs/plans/`, `docs/CYCLE_PREDICTION_FALLBACK_LOGIC.md` and `docs/CYCLE_PREDICTION_TEST_PLAN.md`.
+
+**An architecture decision record goes in `docs/adr/`**, numbered in sequence (`0003-...`) and following the format of the two already there. Write one when you make a decision a future reader would otherwise re-litigate. Implementation plans go in `docs/plans/`, and the instructions the agent skills read go in `docs/agents/`.
+
+Documentation never goes under `docs/src/`. That is the website.
 
 ## Key Components
 


### PR DESCRIPTION
Closes #208.

## What changed

`PROJECTSTRUCTURE.md` only. No file under `docs/` was moved, renamed or deleted, and the Astro config and Vercel setup are untouched.

- The folder-structure line `├── docs/  # Astro web page` now reads `# Two things: the Astro web page, and the documentation root`.
- A new short section under the block splits the directory into its two halves by name: the Astro site (`astro.config.mjs`, `src/`, `public/`, `tailwind.config.mjs`, `dist/`, its own `package.json`/`node_modules/`) and the documentation root (`adr/`, `agents/`, `plans/`, and the two `CYCLE_PREDICTION_*.md` files).
- It says explicitly that an ADR goes in `docs/adr/`, numbered in sequence, since that is the thing a contributor is least likely to guess.

## One adjacent thing, deliberately

The folder-structure block listed `constants/` **twice**, with two different comments (`# App-wide constants (colors, fonts, etc.)` and `# Constants (colors, TS interfaces, etc.)`). I merged them into one line rather than leave a duplicate in a block I was already editing. That is the only change beyond the issue's three bullets. I did not add the missing `services/`, `stores/`, `utils/`, `plugins/` or `data/` entries; that is a separate cleanup and not what this issue asked for.

## Verification

`npx prettier --write PROJECTSTRUCTURE.md` reports the file unchanged, so the markdown is already in the repo's format.

```
$ npx eslint . --max-warnings=0
exit=0    (no output)

$ npm run typecheck
> ephira@1.3.0 typecheck
> tsc --noEmit
exit=0

$ npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       232 passed, 232 total
Snapshots:   0 total
Time:        1.693 s
exit=0

$ TZ=Europe/Brussels npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       232 passed, 232 total
Snapshots:   0 total
Time:        1.518 s
exit=0
```
