### PR TITLE
fix: hide the home phase until two cycles are logged

### DIFF
--- a/__tests__/cycleState.test.ts
+++ b/__tests__/cycleState.test.ts
@@ -204,6 +204,24 @@ describe("currentCycleState", () => {
     expect(state?.nextPredictedStart).toBeNull();
   });
 
+  it("does not claim enough data from a single cycle", () => {
+    // The home screen renders the phase button off this flag (#163). One
+    // logged cycle is enough to know the phase and not enough to show it.
+    const state = currentCycleState(cycleWithFlow, [], localDay("2026-01-11"));
+
+    expect(countCompleteCycles(cycleWithFlow)).toBe(1);
+    expect(state?.hasEnoughData).toBe(false);
+  });
+
+  it("claims enough data once a second cycle is logged", () => {
+    const twoCycles = [...run(1, 1, 5), ...run(10, 10, 5)];
+
+    const state = currentCycleState(twoCycles, [], localDay("2026-01-20"));
+
+    expect(countCompleteCycles(twoCycles)).toBe(2);
+    expect(state?.hasEnoughData).toBe(true);
+  });
+
   it("gates on the same count the settings screen uses", () => {
     const oneCycle = currentCycleState(
       cycleWithFlow,

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -79,9 +79,13 @@ export default function HomeScreen() {
     .sort((a, b) => new Date(b.date).valueOf() - new Date(a.date).valueOf())
     .slice(0, 5);
 
-  // Get current phase name
-  const currentPhase = cycleState
-    ? CYCLE_PHASES[cycleState.currentPhase]
+  // The phase is knowable from one logged cycle, and the home screen is the
+  // thing that requires two before showing it (#163). `hasEnoughData` is
+  // countCompleteCycles(...) >= MIN_CYCLES_FOR_PREDICTION, the same gate the
+  // settings screen and the cycle tab's prediction card already use.
+  const shownCycleState = cycleState?.hasEnoughData ? cycleState : null;
+  const currentPhase = shownCycleState
+    ? CYCLE_PHASES[shownCycleState.currentPhase]
     : null;
   const phaseName = currentPhase ? currentPhase.name : null;
 
@@ -95,8 +99,9 @@ export default function HomeScreen() {
         <View
           style={{ flex: 1, justifyContent: "center", alignContent: "center" }}
         >
-          {/* Current Phase Button - show placeholder while loading */}
-          {(phaseName && currentPhase) || cycleLoading ? (
+          {/* The placeholder is for a cycle state not yet known, not for one
+              known to be short of two cycles. */}
+          {(phaseName && currentPhase) || (cycleLoading && !cycleState) ? (
             <Pressable
               onPress={handlePhasePress}
               hitSlop={{


### PR DESCRIPTION
Closes #163.

## What changed

`app/(tabs)/index.tsx` renders the phase button only when `cycleState.hasEnoughData` is true.

That flag is `countCompleteCycles(flowData) >= MIN_CYCLES_FOR_PREDICTION` (2), already computed by `currentCycleState` and already the gate used by `components/settings/CyclePrediction.tsx` and by the cycle tab's prediction card (`app/(tabs)/cycle.tsx:208`). The home screen was the one reader that never consulted it.

The gate is in the screen, not in the module, as the issue's diagnostic comment argued: with one cycle the phase genuinely is known, and the cycle tab shows it legitimately. The home screen is the thing with the requirement.

The loading placeholder moved with it: `(phaseName && currentPhase) || cycleLoading` became `(phaseName && currentPhase) || (cycleLoading && !cycleState)`. Without that second half, a 1-cycle user would keep the button on screen for as long as `getPredictionAccuracy()` takes, which is a persistent wrong render rather than a flash.

## The title condition, and a defect it turned up

The issue title says "even with the Cycle Tracking Disabled", which is the settings toggle (`predictionChoice`), while the body and the reproduction are the insufficient-data case. The diagnostic comment asked which of the two the phase should hide on, and said to state the answer here.

**This PR gates on `hasEnoughData` only, and deliberately does not consult `predictionChoice`.** The reason is not a preference:

- `usePredictionChoice` initialises to `false` (`stores/calendar-storage.tsx:65-69`).
- It is hydrated from storage in exactly one place, a `useEffect` on the Calendar screen (`app/(tabs)/calendar.tsx:82-97`). Nothing in `app/_layout.tsx` loads it, though that file already hydrates `SettingsKeys.trackingMode` the same way.
- Bottom tabs mount lazily and Home is the initial route, so on a cold start the store says `false` regardless of what the user has actually chosen.

Gating the home phase on it would therefore hide the phase on every cold start for every user with predictions enabled, until they happened to visit the Calendar tab. That is a worse bug than the one being fixed.

The unhydrated store is a live defect on its own, and `app/(tabs)/cycle.tsx:154` reproduces it today: cold start straight to the Cycle tab renders "Cycle Predictions Disabled" to a user whose setting on disk says `true`. Filed as **#210** rather than folded in here, since the fix belongs in `app/_layout.tsx`. Once that lands, whether the home phase should also hide when the user has switched predictions off is a product question worth answering on its own.

## Testing, honestly

**There is no red-to-green here, and I am not going to dress one up.** `hasEnoughData` was already correct; the defect was that the JSX never read it. No module-level test could fail before this change.

What I added to `__tests__/cycleState.test.ts` are two concrete-value assertions pinning the value the screen now depends on:

- one 5-day run → `countCompleteCycles` is 1 and `hasEnoughData` is `false`
- two 5-day runs → `countCompleteCycles` is 2 and `hasEnoughData` is `true`

These sit beside the existing `gates on the same count the settings screen uses`, which asserts `hasEnoughData === (countCompleteCycles(...) >= MIN_CYCLES_FOR_PREDICTION)` and so holds by construction for any implementation. I left it alone and did not extend it.

I did not build a component-test harness for `app/(tabs)/index.tsx`. It would pull in expo-router, `LinearGradient`, `TourAnchor` and four stores, and there are no component tests of screens in this repo to follow. The screen change is four lines and reviewable by reading.

## Assumption stated

A user with exactly one logged cycle will briefly see "Loading phase..." before it disappears, because `cycleLoading` tracks `getPredictionAccuracy()` rather than whether the cycle data is known. That is the same behaviour a user with zero cycles gets on `main` today, so it is not a regression, and closing it properly means a real loading signal for cycle data, which this issue did not ask for.

## Verification

```
$ npx eslint . --max-warnings=0
exit=0    (no output)

$ npm run typecheck
> ephira@1.3.0 typecheck
> tsc --noEmit
exit=0

$ npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       234 passed, 234 total
Snapshots:   0 total
Time:        1.485 s
exit=0

$ TZ=Europe/Brussels npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       234 passed, 234 total
Snapshots:   0 total
Time:        1.27 s
exit=0
```

(232 on `main`, 234 here: the two new assertions.)
