### PR TITLE
fix: write a pending day edit instead of dropping it on a date change

### DIFF
--- a/components/dayView/DayView.tsx
+++ b/components/dayView/DayView.tsx
@@ -98,9 +98,18 @@ export default function DayView() {
 
     setExpandedAccordion(null);
 
+    // Flush, not cancel. The pending edit was made against the day that is
+    // closing, so it belongs to that day. Cancelling here is what dropped a
+    // flow selected less than the debounce before tapping another date (#162).
+    //
+    // This cleanup runs before the new date's effect, so the flush starts
+    // while the saver's baseline is still the old day and its wrong-day guard
+    // passes. The new day's reset lands later, once its loadLoggedDay
+    // resolves, and the saver declines to move a baseline onto a day it did
+    // not save. Inverting that order reintroduces the bug as a wrong-day.
     return () => {
       stale = true;
-      saver.cancel();
+      saver.flush();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [date, databaseChange]);

--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -358,21 +358,26 @@ describe("the saver's timing rules", () => {
   });
 
   it("does not move the baseline onto a day that is no longer open", async () => {
-    // The flush settled after reset, so the new day's baseline is the new
-    // day's contents and an edit to it is still detected as a change.
+    // The flush settles after the new day's reset, so the baseline has to be
+    // the new day's real contents, not the snapshot the flush just wrote.
+    const newDay = aDay({ date: OTHER_DATE, flow: 1 });
     const saver = createLoggedDaySaver();
     saver.reset(emptyLoggedDay(DATE));
 
     saver.schedule(aDay({ flow: 3 }));
     const flushed = saver.flush();
-    saver.reset(emptyLoggedDay(OTHER_DATE));
+    saver.reset(newDay);
     await flushed;
 
-    const next = saver.schedule(aDay({ date: OTHER_DATE, flow: 1 }));
+    // Unchanged, not wrong-day: the baseline still names the new day, and it
+    // still holds what was loaded for it.
+    expect((await saver.schedule(newDay)).status).toBe("unchanged");
+
+    const edited = saver.schedule({ ...newDay, flow: 2 });
     await settle();
 
-    expect((await next).status).toBe("saved");
-    expect((await getDay(OTHER_DATE))?.flow_intensity).toBe(1);
+    expect((await edited).status).toBe("saved");
+    expect((await getDay(OTHER_DATE))?.flow_intensity).toBe(2);
   });
 
   it("has nothing to flush when no write is pending", async () => {

--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -26,6 +26,7 @@ jest.mock("@/db/operations/setup", () =>
 );
 
 const DATE = "2026-04-01";
+const OTHER_DATE = "2026-04-02";
 
 const aDay = (overrides: Partial<LoggedDay> = {}): LoggedDay => ({
   ...emptyLoggedDay(DATE),
@@ -321,6 +322,64 @@ describe("the saver's timing rules", () => {
     await settle();
 
     expect((await pending).status).toBe("superseded");
+    expect(await getDay(DATE)).toBeUndefined();
+  });
+
+  it("writes a pending edit when the day changes rather than dropping it", async () => {
+    // The report: select a flow, tap another day inside the 100ms debounce,
+    // and the flow was silently discarded (#162). The user's edit was to the
+    // old day, and writing the old snapshot to the old date is correct.
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    const pending = saver.schedule(aDay({ flow: 3 }));
+    const flushed = await saver.flush();
+
+    expect(flushed.status).toBe("saved");
+    expect((await pending).status).toBe("saved");
+    expect((await getDay(DATE))?.flow_intensity).toBe(3);
+  });
+
+  it("keeps the flushed write on the old day when the new day's load lands first", async () => {
+    // DayView flushes in the load effect's cleanup, so the flush starts before
+    // loadLoggedDay resolves and calls reset for the new day. The flushed
+    // write must still land on the day it was made against.
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    const pending = saver.schedule(aDay({ flow: 3 }));
+    const flushed = saver.flush();
+    saver.reset(emptyLoggedDay(OTHER_DATE));
+
+    expect((await flushed).status).toBe("saved");
+    expect((await pending).status).toBe("saved");
+    expect((await getDay(DATE))?.flow_intensity).toBe(3);
+    expect(await getDay(OTHER_DATE)).toBeUndefined();
+  });
+
+  it("does not move the baseline onto a day that is no longer open", async () => {
+    // The flush settled after reset, so the new day's baseline is the new
+    // day's contents and an edit to it is still detected as a change.
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    saver.schedule(aDay({ flow: 3 }));
+    const flushed = saver.flush();
+    saver.reset(emptyLoggedDay(OTHER_DATE));
+    await flushed;
+
+    const next = saver.schedule(aDay({ date: OTHER_DATE, flow: 1 }));
+    await settle();
+
+    expect((await next).status).toBe("saved");
+    expect((await getDay(OTHER_DATE))?.flow_intensity).toBe(1);
+  });
+
+  it("has nothing to flush when no write is pending", async () => {
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    expect((await saver.flush()).status).toBe("unchanged");
     expect(await getDay(DATE)).toBeUndefined();
   });
 

--- a/db/loggedDay.ts
+++ b/db/loggedDay.ts
@@ -352,6 +352,16 @@ export type LoggedDaySaver = {
   reset(day: LoggedDay): void;
   /** Debounced and guarded. Resolves with what actually happened. */
   schedule(day: LoggedDay): Promise<SaveOutcome>;
+  /**
+   * Writes a pending edit now instead of waiting out the debounce.
+   *
+   * This is what a day change wants. The edit was made against the day that
+   * is closing, so writing it to that day is right; cancelling would drop it,
+   * which is what made a flow selected and abandoned inside 100ms vanish.
+   * Resolves `unchanged` when there was nothing pending.
+   */
+  flush(): Promise<SaveOutcome>;
+  /** Discards a pending edit. For teardown that should not write. */
   cancel(): void;
 };
 
@@ -371,6 +381,10 @@ export const DEFAULT_SAVE_DELAY_MS = 100;
  *   day's contents against the new day.
  * - **Right day, after.** The baseline only moves forward if the open day is
  *   still the one that was saved.
+ *
+ * The debounce elapsing is not the only reason to write. `flush` runs the
+ * same pending write immediately, under the same four rules, which is what
+ * closing a day needs.
  */
 export function createLoggedDaySaver(
   options: { delayMs?: number } = {},
@@ -379,21 +393,64 @@ export function createLoggedDaySaver(
 
   let baseline: LoggedDay | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let supersede: ((outcome: SaveOutcome) => void) | null = null;
+  let pending: {
+    day: LoggedDay;
+    resolve: (outcome: SaveOutcome) => void;
+  } | null = null;
   let inFlight = false;
 
-  const clearPending = (outcome: SaveOutcome) => {
+  const takePending = () => {
     if (timer) clearTimeout(timer);
     timer = null;
-    const resolvePending = supersede;
-    supersede = null;
-    resolvePending?.(outcome);
+    const taken = pending;
+    pending = null;
+    return taken;
+  };
+
+  const clearPending = (outcome: SaveOutcome) => {
+    takePending()?.resolve(outcome);
+  };
+
+  /**
+   * The write itself, whether the debounce elapsed or a flush asked for it
+   * now. Resolves whoever called `schedule` and returns the same outcome to
+   * whoever asked for the flush.
+   */
+  const runPending = async (): Promise<SaveOutcome> => {
+    const taken = takePending();
+    if (!taken) return { status: "unchanged" };
+
+    const { day, resolve } = taken;
+    const settle = (outcome: SaveOutcome) => {
+      resolve(outcome);
+      return outcome;
+    };
+
+    if (inFlight) return settle({ status: "superseded" });
+    if (baseline && baseline.date !== day.date) {
+      return settle({ status: "wrong-day" });
+    }
+
+    inFlight = true;
+    try {
+      await saveLoggedDay(day);
+      if (baseline?.date === day.date) baseline = day;
+      return settle({ status: "saved", day });
+    } catch (error) {
+      return settle({ status: "failed", error });
+    } finally {
+      inFlight = false;
+    }
   };
 
   return {
     reset(day) {
       clearPending({ status: "superseded" });
       baseline = day;
+    },
+
+    flush() {
+      return runPending();
     },
 
     cancel() {
@@ -411,26 +468,9 @@ export function createLoggedDaySaver(
       clearPending({ status: "superseded" });
 
       return new Promise<SaveOutcome>((resolve) => {
-        supersede = resolve;
-        timer = setTimeout(async () => {
-          timer = null;
-          supersede = null;
-
-          if (inFlight) return resolve({ status: "superseded" });
-          if (baseline && baseline.date !== day.date) {
-            return resolve({ status: "wrong-day" });
-          }
-
-          inFlight = true;
-          try {
-            await saveLoggedDay(day);
-            if (baseline?.date === day.date) baseline = day;
-            resolve({ status: "saved", day });
-          } catch (error) {
-            resolve({ status: "failed", error });
-          } finally {
-            inFlight = false;
-          }
+        pending = { day, resolve };
+        timer = setTimeout(() => {
+          void runPending();
         }, delayMs);
       });
     },


### PR DESCRIPTION
Closes #162.

## The defect

`components/dayView/DayView.tsx` cleared the pending save in the load effect's cleanup, and that cleanup runs on every `date` change. A flow selected less than 100ms before tapping another date was discarded and never written. That is the report, including "user has to wait before changing date".

## The fix

`LoggedDaySaver` grows `flush()`, and `DayView` calls it instead of `cancel()` when the day closes.

Cancel is the wrong verb on a date change. The edit was made against the day that is *closing*, so writing it to that day is right. The genuinely dangerous case, writing the old snapshot against the *new* date, is already prevented by the saver's `wrong-day` guard, which flush runs under unchanged.

The timer path and the flush path are now one function, `runPending`. The debounce elapsing is one of two reasons to write, not the definition of writing. Both go through the same four rules, and both resolve the original `schedule` caller with the real outcome, so the day view's save message keeps working either way.

`flush()` with nothing pending resolves `{ status: "unchanged" }` rather than introducing a new status variant. Nothing pending means nothing to write, which is what `unchanged` already says.

## The reset interaction, which is the part worth reviewing

The issue flagged it: the new day's `loadLoggedDay` must not move the baseline before the flush has settled, or the flushed write gets re-detected as a change.

It does not, and the ordering is now pinned by a test rather than by argument:

1. React runs the old effect's cleanup **before** the new effect. So at flush time `baseline` still names the old day, and the `wrong-day` guard passes.
2. `reset(newDay)` lands later, when the new day's `loadLoggedDay` resolves. It can land while the flushed write is still in flight.
3. When that write finishes, `if (baseline?.date === day.date) baseline = day` is false, so the baseline is left pointing at the new day's real contents. An edit to the new day is still detected as a change.

The comment in `DayView` says this explicitly, because inverting the order reintroduces exactly this bug as a `wrong-day`.

## Tests

Red first: all four new tests failed with `saver.flush is not a function` before the implementation.

Added to `db/__tests__/loggedDay.test.ts`, beside the six existing timing rules:

- `writes a pending edit when the day changes rather than dropping it` — the reported reproduction: schedule an edit, flush before the debounce elapses, assert the day was written.
- `keeps the flushed write on the old day when the new day's load lands first` — flush, then `reset` to another date before awaiting; the write lands on the old date and the new date has no row.
- `does not move the baseline onto a day that is no longer open` — after that sequence, scheduling the new day's own contents comes back `unchanged`, so the baseline holds what was loaded for the new day rather than what the flush wrote. Deleting the `if (baseline?.date === day.date)` check turns this red; I ran that mutation to confirm the test discriminates.
- `has nothing to flush when no write is pending`.

The six existing timing tests are unchanged and still pass; `runPending` keeps the same await depth as the timer body it replaces, so `advanceTimersByTime(100); await Promise.resolve()` still behaves the same.

## The other effect on the same date, traced

`flush()` makes a path live that `cancel()` closed off, so it is worth stating rather than leaving implicit. React runs *all* cleanups before *any* new effect body, so on a date change the order is:

1. Load effect cleanup: `saver.flush()`. `baseline` still names the old day, so the write goes to the old date.
2. Load effect body: `loaded.current = false` synchronously, then `loadLoggedDay(newDate)` starts.
3. Auto-save effect body: `if (!date || !loaded.current) return;` returns.

Step 3 matters because `day` state still holds the *old* day's contents at that point, and the auto-save effect depends on `date`, so it re-runs. `loaded.current = false` is the only thing stopping `saver.schedule(oldDay)` from running while `date` is the new one. It holds because the load effect is declared before the auto-save effect and sets the flag synchronously. If those two effects are ever reordered, this breaks, though the saver's `wrong-day` guard would catch it rather than corrupting a day.

## Two things to flag

**`cancel()` now has no caller in the app.** The issue reserved it for genuine teardown, so I kept it on the interface and its test. But the only cleanup a component has runs for both a date change and an unmount, and React does not distinguish them, so there is nowhere left that wants a discard. Flushing on unmount is arguably the better behaviour anyway: tabbing away from the calendar should not lose a flow either. Deleting `cancel()` is a defensible follow-up; I did not do it unilaterally because the issue asked for it to stay.

**The responsiveness half of the report is not addressed here.** "The time to log the flow feels awfully long" is a separate claim from the dropped write, and I cannot measure device latency from here. #202 already took opening a day from 7+ queries plus a per-entry fan-out down to 4 fixed queries, and the save message already renders from the in-memory snapshot rather than a re-read, so the optimistic-update suggestion in the report is largely already true. Worth re-testing on device after this lands; if it still feels slow, that is a new issue with a measurement in it rather than a guess.

## Verification

```
$ npx eslint . --max-warnings=0
exit=0    (no output)

$ npm run typecheck
> ephira@1.3.0 typecheck
> tsc --noEmit
exit=0

$ npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       236 passed, 236 total
Snapshots:   0 total
Time:        2.562 s
exit=0

$ TZ=Europe/Brussels npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       236 passed, 236 total
Snapshots:   0 total
Time:        2.281 s
exit=0
```

(232 on `main`, 236 here: the four new tests.)
