### PR TITLE
refactor: move the cycle store's shapes beside the store

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,8 +32,8 @@ This file is maintained lazily: terms are added when a design decision actually 
 
 ## Terms we avoid
 
-**`Mood`, `Symptom`, `Medication` as UI state.** These names belong to the Catalogue entities in `db/schema.ts`. `constants/Interfaces.ts` currently also uses them for selection state, so `Mood` means two different things depending on the import. Selection state is part of a Logged Day and is named accordingly.
+**`Mood`, `Symptom`, `Medication` as UI state.** These names belong to the Catalogue entities in `db/schema.ts`. `constants/Interfaces.ts` used them for selection state as well, so `Mood` meant two different things depending on the import; those declarations are gone. Selection state is part of a Logged Day and is named accordingly.
 
 **"Component", "service", "wrapper", "layer", "boundary".** Architecture discussion uses the vocabulary in `docs/agents/domain.md` and the `codebase-design` skill: module, interface, implementation, depth, seam, adapter, leverage, locality.
 
-**"Period" as a synonym for Cycle.** `periodData` in `constants/Interfaces.ts` is a drawing instruction for the calendar, not a domain concept. Say Cycle for the domain, Marked Dates for the drawing.
+**"Period" as a synonym for Cycle.** `PeriodData` in `constants/Interfaces.ts` is a drawing instruction for the calendar, not a domain concept. Say Cycle for the domain, Marked Dates for the drawing.

--- a/components/calendar/CustomDay.tsx
+++ b/components/calendar/CustomDay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { useTheme } from "react-native-paper";
 import type { DateData } from "react-native-calendars";
-import type { MarkedDate, periodData } from "@/constants/Interfaces";
+import type { MarkedDate, PeriodData } from "@/constants/Interfaces";
 
 type DayState = "selected" | "disabled" | "inactive" | "today" | "";
 
@@ -95,7 +95,7 @@ export default function CustomDay({
 
       {/* Period markers */}
       <View style={styles.periodsContainer}>
-        {periods.map((period: periodData, index: number) => (
+        {periods.map((period: PeriodData, index: number) => (
           <View
             key={index}
             style={[

--- a/constants/Interfaces.ts
+++ b/constants/Interfaces.ts
@@ -1,3 +1,12 @@
+/**
+ * The domain and view data types the app passes around.
+ *
+ * Zustand store shapes used to live here too, which made this one file because
+ * everything in it was an `interface` and for no other reason. They are now
+ * declared beside their store in `stores/calendar-storage.tsx`, un-exported,
+ * matching `stores/pregnancy-storage.tsx`.
+ */
+
 export interface DayData {
   id: number;
   date: string;
@@ -12,7 +21,7 @@ export interface DayData {
   birth_control?: string;
 }
 
-export interface periodData {
+export interface PeriodData {
   startingDay?: boolean;
   endingDay?: boolean;
   color: string;
@@ -21,52 +30,13 @@ export interface periodData {
 
 export interface MarkedDate {
   selected: boolean;
-  periods: periodData[];
+  periods: PeriodData[];
   hasBirthControl?: boolean;
   hasIntercourse?: boolean;
 }
 
 export interface MarkedDates {
   [key: string]: MarkedDate;
-}
-
-/**
- * The selected date, and nothing else.
- *
- * The date is genuinely shared: the calendar picks it and the day view reads
- * it. The selected day's *contents* were only ever global so that accordions
- * and fetch hooks could talk past each other, which db/loggedDay.ts absorbed.
- */
-export interface SelectedDateStore {
-  date: string;
-  setDate: (date: string) => void;
-}
-
-export interface LoadData {
-  data: DayData[];
-  show: boolean;
-  setData: (data: DayData[]) => void;
-  setShow: (show: boolean) => void;
-}
-
-export interface FlowDataState {
-  flowDataForCurrentMonth: DayData[];
-  setFlowDataForCurrentMonth: (data: DayData[]) => void;
-}
-
-export interface CalendarFilters {
-  selectedFilters: string[];
-  setSelectedFilters: (values: string[]) => void;
-}
-
-export interface ThemeColor {
-  themeColor: string;
-  setThemeColor: (color: string) => void;
-}
-
-export interface DatabaseChangeNotifier {
-  databaseChange: string;
-  setDatabaseChange: (databaseChange: string) => void;
 }
 
 export interface ExportDataHeaders {
@@ -100,21 +70,9 @@ export interface ExportData {
   dailyData: Record<string, ExportDayEntry>;
 }
 
-export interface PredictionToggle {
-  predictionChoice: boolean;
-  setPredictionChoice: (predictionChoice: boolean) => void;
-}
-
 export interface PredictedDate {
   date: string;
   confidence: number; // 0-100
-}
-
-export interface PredictedCycleState {
-  predictedCycle: PredictedDate[];
-  predictedMarkedDates: MarkedDates;
-  setPredictedCycle: (data: PredictedDate[]) => void;
-  setPredictedMarkedDates: (data: MarkedDates) => void;
 }
 
 export interface CurrentCycleState {
@@ -126,11 +84,6 @@ export interface CurrentCycleState {
   nextPredictedStart: string | null;
   confidence: number;
   hasEnoughData: boolean;
-}
-
-export interface TrackingMode {
-  trackingMode: string;
-  setTrackingMode: (mode: string) => void;
 }
 
 export interface CycleStats {

--- a/stores/calendar-storage.tsx
+++ b/stores/calendar-storage.tsx
@@ -1,18 +1,19 @@
 import { create } from "zustand";
-import {
+import type {
   DayData,
-  SelectedDateStore,
-  LoadData,
   MarkedDates,
-  FlowDataState,
-  CalendarFilters,
-  ThemeColor,
-  DatabaseChangeNotifier,
-  PredictionToggle,
-  PredictedCycleState,
   PredictedDate,
-  TrackingMode,
 } from "@/constants/Interfaces";
+
+/**
+ * Cycle-mode app state. `stores/pregnancy-storage.tsx` is its counterpart.
+ *
+ * Each store's shape is declared here, beside the store, and is not exported.
+ * A shape with no reader outside its own store should not be importable: it
+ * describes how this file holds something, not a thing the app has. The types
+ * that cross the boundary are the domain and view types in
+ * `constants/Interfaces.ts`, which the shapes below reference.
+ */
 
 /**
  * The selected date. Its only writer is the calendar's day press.
@@ -21,10 +22,22 @@ import {
  * id nothing read. Those are the contents of a Logged Day, which db/loggedDay.ts
  * owns; keeping them here meant every reader re-rendered when any of them moved.
  */
+interface SelectedDateStore {
+  date: string;
+  setDate: (date: string) => void;
+}
+
 export const useSelectedDate = create<SelectedDateStore>((set) => ({
   date: "",
   setDate: (date: string) => set(() => ({ date })),
 }));
+
+interface LoadData {
+  data: DayData[];
+  show: boolean;
+  setData: (data: DayData[]) => void;
+  setShow: (show: boolean) => void;
+}
 
 export const useData = create<LoadData>((set) => ({
   data: [],
@@ -37,11 +50,21 @@ export const useData = create<LoadData>((set) => ({
   },
 }));
 
+interface FlowDataState {
+  flowDataForCurrentMonth: DayData[];
+  setFlowDataForCurrentMonth: (data: DayData[]) => void;
+}
+
 export const useFlowData = create<FlowDataState>((set) => ({
   flowDataForCurrentMonth: [],
   setFlowDataForCurrentMonth: (data: DayData[]) =>
     set(() => ({ flowDataForCurrentMonth: data })),
 }));
+
+interface CalendarFilters {
+  selectedFilters: string[];
+  setSelectedFilters: (values: string[]) => void;
+}
 
 export const useCalendarFilters = create<CalendarFilters>((set) => ({
   selectedFilters: [],
@@ -49,10 +72,20 @@ export const useCalendarFilters = create<CalendarFilters>((set) => ({
     set(() => ({ selectedFilters: values })),
 }));
 
+interface ThemeColor {
+  themeColor: string;
+  setThemeColor: (color: string) => void;
+}
+
 export const useThemeColor = create<ThemeColor>((set) => ({
   themeColor: "",
   setThemeColor: (color: string) => set(() => ({ themeColor: color })),
 }));
+
+interface DatabaseChangeNotifier {
+  databaseChange: string;
+  setDatabaseChange: (databaseChange: string) => void;
+}
 
 export const useDatabaseChangeNotifier = create<DatabaseChangeNotifier>(
   (set) => ({
@@ -62,11 +95,23 @@ export const useDatabaseChangeNotifier = create<DatabaseChangeNotifier>(
   }),
 );
 
+interface PredictionToggle {
+  predictionChoice: boolean;
+  setPredictionChoice: (predictionChoice: boolean) => void;
+}
+
 export const usePredictionChoice = create<PredictionToggle>((set) => ({
   predictionChoice: false,
   setPredictionChoice: (predictionChoice: boolean) =>
     set(() => ({ predictionChoice: predictionChoice })),
 }));
+
+interface PredictedCycleState {
+  predictedCycle: PredictedDate[];
+  predictedMarkedDates: MarkedDates;
+  setPredictedCycle: (data: PredictedDate[]) => void;
+  setPredictedMarkedDates: (data: MarkedDates) => void;
+}
 
 export const usePredictedCycle = create<PredictedCycleState>((set) => ({
   predictedCycle: [],
@@ -76,6 +121,11 @@ export const usePredictedCycle = create<PredictedCycleState>((set) => ({
   setPredictedMarkedDates: (data: MarkedDates) =>
     set(() => ({ predictedMarkedDates: data })),
 }));
+
+interface TrackingMode {
+  trackingMode: string;
+  setTrackingMode: (mode: string) => void;
+}
 
 export const useTrackingMode = create<TrackingMode>((set) => ({
   trackingMode: "cycle",


### PR DESCRIPTION
Closes #207.

Type and import moves only. No behaviour change.

## What moved

The nine Zustand store shapes are now declared in `stores/calendar-storage.tsx`, un-exported, matching `stores/pregnancy-storage.tsx`: `SelectedDateStore`, `LoadData`, `FlowDataState`, `CalendarFilters`, `ThemeColor`, `DatabaseChangeNotifier`, `PredictionToggle`, `PredictedCycleState`, `TrackingMode`.

I checked each one before moving it, as the issue asked. **None of the nine had a reader outside `stores/calendar-storage.tsx`.** Every remaining reference in the app is to the exported hook (`useDatabaseChangeNotifier` and friends), which is a value, not the type.

`PredictedDate` stays in `constants/Interfaces.ts`. It is domain data, referenced by `services/cyclePredictions.ts`, `services/cyclePredictionLogic.ts`, `services/notificationService.ts`, `hooks/useCyclePhase.ts` and `components/cycle/PredictionCard.tsx`. `PredictedCycleState` still imports it, along with `MarkedDates`, from `constants/Interfaces.ts`; that is the store shape referencing view types, which is the right direction.

`constants/Interfaces.ts` keeps the domain and view types and gains a header saying where the store shapes went.

## Placement, one small deviation

`stores/pregnancy-storage.tsx` declares its three shapes in a block at the top. With nine, I put each interface **directly above the store that uses it** instead. Same rule (inline, un-exported), better locality: a store and its shape change together, and nine declarations stacked at the top would put them a screen away from their only reader. Happy to reshuffle into one block if you would rather the two files match line for line.

## `periodData` → `PeriodData`

Renamed. It was the one lowercase-named type in the file, which reads as an instance rather than a type. Two call sites: `MarkedDate.periods` and `components/calendar/CustomDay.tsx`.

`CONTEXT.md` names it by its exact spelling under "Terms we avoid", so the glossary is updated in the same commit. Without that the glossary would point at a type that no longer exists.

## One adjacent correction to `CONTEXT.md`

The "Terms we avoid" entry above it still said `constants/Interfaces.ts` **currently** declares `Mood`, `Symptom` and `Medication` for selection state, so `Mood` means two things depending on the import. That stopped being true in #203; those declarations are gone. Changed to past tense, since a glossary that describes a hazard that no longer exists sends the next reader looking for it.

No ADR. The issue is explicit that this is not a new convention, just the cycle store catching up with the pregnancy one.

## Verification

The typecheck is the real gate for this one, and it passes clean.

```
$ npx eslint . --max-warnings=0
exit=0    (no output)

$ npm run typecheck
> ephira@1.3.0 typecheck
> tsc --noEmit
exit=0

$ npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       232 passed, 232 total
Snapshots:   0 total
Time:        1.428 s
exit=0

$ TZ=Europe/Brussels npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       232 passed, 232 total
Snapshots:   0 total
Time:        1.288 s
exit=0
```

232 on `main` and 232 here, which is what a no-behaviour-change refactor should look like. `npx prettier --check` is clean on all four files.
