### PR TITLE
fix: disarm a pending write the user has backed out of

### DIFF
--- a/components/dayView/DayView.tsx
+++ b/components/dayView/DayView.tsx
@@ -98,9 +98,18 @@ export default function DayView() {
 
     setExpandedAccordion(null);
 
+    // Flush, not cancel. The pending edit was made against the day that is
+    // closing, so it belongs to that day. Cancelling here is what dropped a
+    // flow selected less than the debounce before tapping another date (#162).
+    //
+    // This cleanup runs before the new date's effect, so the flush starts
+    // while the saver's baseline is still the old day and its wrong-day guard
+    // passes. The new day's reset lands later, once its loadLoggedDay
+    // resolves, and the saver declines to move a baseline onto a day it did
+    // not save. Inverting that order reintroduces the bug as a wrong-day.
     return () => {
       stale = true;
-      saver.cancel();
+      saver.flush();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [date, databaseChange]);

--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -380,6 +380,45 @@ describe("the saver's timing rules", () => {
     expect((await getDay(OTHER_DATE))?.flow_intensity).toBe(2);
   });
 
+  it("disarms a pending write the user has backed out of", async () => {
+    // Select Heavy, change your mind back to None inside the debounce. The
+    // second schedule sees nothing changed against the baseline, and the
+    // first write must not still be armed behind it (#214).
+    const saver = createLoggedDaySaver();
+    const none = emptyLoggedDay(DATE);
+    saver.reset(none);
+
+    const heavy = saver.schedule(aDay({ flow: 3 }));
+    const reverted = await saver.schedule(none);
+
+    await settle();
+    // Await the first schedule, not just the timer. Advancing timers alone
+    // reports a false pass, because the write has not settled by then.
+    const outcome = await heavy;
+
+    // The harm first: the database held Heavy while the UI showed None, and
+    // nothing said so, because the save message renders from the snapshot.
+    expect(await getDay(DATE)).toBeUndefined();
+    expect(reverted.status).toBe("unchanged");
+    expect(outcome.status).toBe("superseded");
+  });
+
+  it("still writes a pending edit for a day that is no longer open", async () => {
+    // The asymmetry. `unchanged` means there is nothing left to write, so it
+    // disarms. `wrong-day` means the edit belongs to another day, and
+    // disarming there is #162.
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    const pending = saver.schedule(aDay({ flow: 3 }));
+    const elsewhere = await saver.schedule(aDay({ date: OTHER_DATE, flow: 1 }));
+    await settle();
+
+    expect(elsewhere.status).toBe("wrong-day");
+    expect((await pending).status).toBe("saved");
+    expect((await getDay(DATE))?.flow_intensity).toBe(3);
+  });
+
   it("has nothing to flush when no write is pending", async () => {
     const saver = createLoggedDaySaver();
     saver.reset(emptyLoggedDay(DATE));

--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -358,21 +358,26 @@ describe("the saver's timing rules", () => {
   });
 
   it("does not move the baseline onto a day that is no longer open", async () => {
-    // The flush settled after reset, so the new day's baseline is the new
-    // day's contents and an edit to it is still detected as a change.
+    // The flush settles after the new day's reset, so the baseline has to be
+    // the new day's real contents, not the snapshot the flush just wrote.
+    const newDay = aDay({ date: OTHER_DATE, flow: 1 });
     const saver = createLoggedDaySaver();
     saver.reset(emptyLoggedDay(DATE));
 
     saver.schedule(aDay({ flow: 3 }));
     const flushed = saver.flush();
-    saver.reset(emptyLoggedDay(OTHER_DATE));
+    saver.reset(newDay);
     await flushed;
 
-    const next = saver.schedule(aDay({ date: OTHER_DATE, flow: 1 }));
+    // Unchanged, not wrong-day: the baseline still names the new day, and it
+    // still holds what was loaded for it.
+    expect((await saver.schedule(newDay)).status).toBe("unchanged");
+
+    const edited = saver.schedule({ ...newDay, flow: 2 });
     await settle();
 
-    expect((await next).status).toBe("saved");
-    expect((await getDay(OTHER_DATE))?.flow_intensity).toBe(1);
+    expect((await edited).status).toBe("saved");
+    expect((await getDay(OTHER_DATE))?.flow_intensity).toBe(2);
   });
 
   it("has nothing to flush when no write is pending", async () => {

--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -26,6 +26,7 @@ jest.mock("@/db/operations/setup", () =>
 );
 
 const DATE = "2026-04-01";
+const OTHER_DATE = "2026-04-02";
 
 const aDay = (overrides: Partial<LoggedDay> = {}): LoggedDay => ({
   ...emptyLoggedDay(DATE),
@@ -321,6 +322,64 @@ describe("the saver's timing rules", () => {
     await settle();
 
     expect((await pending).status).toBe("superseded");
+    expect(await getDay(DATE)).toBeUndefined();
+  });
+
+  it("writes a pending edit when the day changes rather than dropping it", async () => {
+    // The report: select a flow, tap another day inside the 100ms debounce,
+    // and the flow was silently discarded (#162). The user's edit was to the
+    // old day, and writing the old snapshot to the old date is correct.
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    const pending = saver.schedule(aDay({ flow: 3 }));
+    const flushed = await saver.flush();
+
+    expect(flushed.status).toBe("saved");
+    expect((await pending).status).toBe("saved");
+    expect((await getDay(DATE))?.flow_intensity).toBe(3);
+  });
+
+  it("keeps the flushed write on the old day when the new day's load lands first", async () => {
+    // DayView flushes in the load effect's cleanup, so the flush starts before
+    // loadLoggedDay resolves and calls reset for the new day. The flushed
+    // write must still land on the day it was made against.
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    const pending = saver.schedule(aDay({ flow: 3 }));
+    const flushed = saver.flush();
+    saver.reset(emptyLoggedDay(OTHER_DATE));
+
+    expect((await flushed).status).toBe("saved");
+    expect((await pending).status).toBe("saved");
+    expect((await getDay(DATE))?.flow_intensity).toBe(3);
+    expect(await getDay(OTHER_DATE)).toBeUndefined();
+  });
+
+  it("does not move the baseline onto a day that is no longer open", async () => {
+    // The flush settled after reset, so the new day's baseline is the new
+    // day's contents and an edit to it is still detected as a change.
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    saver.schedule(aDay({ flow: 3 }));
+    const flushed = saver.flush();
+    saver.reset(emptyLoggedDay(OTHER_DATE));
+    await flushed;
+
+    const next = saver.schedule(aDay({ date: OTHER_DATE, flow: 1 }));
+    await settle();
+
+    expect((await next).status).toBe("saved");
+    expect((await getDay(OTHER_DATE))?.flow_intensity).toBe(1);
+  });
+
+  it("has nothing to flush when no write is pending", async () => {
+    const saver = createLoggedDaySaver();
+    saver.reset(emptyLoggedDay(DATE));
+
+    expect((await saver.flush()).status).toBe("unchanged");
     expect(await getDay(DATE)).toBeUndefined();
   });
 

--- a/db/loggedDay.ts
+++ b/db/loggedDay.ts
@@ -375,6 +375,9 @@ export const DEFAULT_SAVE_DELAY_MS = 100;
  * tested:
  *
  * - **Debounce.** A burst of edits collapses into one write.
+ * - **Back where it started.** A burst that ends at the baseline writes
+ *   nothing, including the pending write it began with. Selecting Heavy and
+ *   reverting to None inside the debounce leaves nothing behind.
  * - **In flight.** A save already running is never re-entered.
  * - **Right day, before.** A snapshot for a day other than the one now open is
  *   not written. The user switching days mid-debounce must not write the old
@@ -458,10 +461,18 @@ export function createLoggedDaySaver(
     },
 
     schedule(day) {
+      // Deliberately does not disarm. A pending edit belongs to the day it
+      // was made against, and this call is about a different day; discarding
+      // it here is the bug #162 fixed.
       if (baseline && baseline.date !== day.date) {
         return Promise.resolve({ status: "wrong-day" as const });
       }
+
+      // Disarms, because this one means there is nothing left to write. The
+      // user backed out of an edit inside the debounce, so any pending write
+      // is now for a value they have already abandoned (#214).
       if (baseline && !loggedDayChanged(day, baseline)) {
+        clearPending({ status: "superseded" });
         return Promise.resolve({ status: "unchanged" as const });
       }
 

--- a/db/loggedDay.ts
+++ b/db/loggedDay.ts
@@ -352,6 +352,16 @@ export type LoggedDaySaver = {
   reset(day: LoggedDay): void;
   /** Debounced and guarded. Resolves with what actually happened. */
   schedule(day: LoggedDay): Promise<SaveOutcome>;
+  /**
+   * Writes a pending edit now instead of waiting out the debounce.
+   *
+   * This is what a day change wants. The edit was made against the day that
+   * is closing, so writing it to that day is right; cancelling would drop it,
+   * which is what made a flow selected and abandoned inside 100ms vanish.
+   * Resolves `unchanged` when there was nothing pending.
+   */
+  flush(): Promise<SaveOutcome>;
+  /** Discards a pending edit. For teardown that should not write. */
   cancel(): void;
 };
 
@@ -371,6 +381,10 @@ export const DEFAULT_SAVE_DELAY_MS = 100;
  *   day's contents against the new day.
  * - **Right day, after.** The baseline only moves forward if the open day is
  *   still the one that was saved.
+ *
+ * The debounce elapsing is not the only reason to write. `flush` runs the
+ * same pending write immediately, under the same four rules, which is what
+ * closing a day needs.
  */
 export function createLoggedDaySaver(
   options: { delayMs?: number } = {},
@@ -379,21 +393,64 @@ export function createLoggedDaySaver(
 
   let baseline: LoggedDay | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
-  let supersede: ((outcome: SaveOutcome) => void) | null = null;
+  let pending: {
+    day: LoggedDay;
+    resolve: (outcome: SaveOutcome) => void;
+  } | null = null;
   let inFlight = false;
 
-  const clearPending = (outcome: SaveOutcome) => {
+  const takePending = () => {
     if (timer) clearTimeout(timer);
     timer = null;
-    const resolvePending = supersede;
-    supersede = null;
-    resolvePending?.(outcome);
+    const taken = pending;
+    pending = null;
+    return taken;
+  };
+
+  const clearPending = (outcome: SaveOutcome) => {
+    takePending()?.resolve(outcome);
+  };
+
+  /**
+   * The write itself, whether the debounce elapsed or a flush asked for it
+   * now. Resolves whoever called `schedule` and returns the same outcome to
+   * whoever asked for the flush.
+   */
+  const runPending = async (): Promise<SaveOutcome> => {
+    const taken = takePending();
+    if (!taken) return { status: "unchanged" };
+
+    const { day, resolve } = taken;
+    const settle = (outcome: SaveOutcome) => {
+      resolve(outcome);
+      return outcome;
+    };
+
+    if (inFlight) return settle({ status: "superseded" });
+    if (baseline && baseline.date !== day.date) {
+      return settle({ status: "wrong-day" });
+    }
+
+    inFlight = true;
+    try {
+      await saveLoggedDay(day);
+      if (baseline?.date === day.date) baseline = day;
+      return settle({ status: "saved", day });
+    } catch (error) {
+      return settle({ status: "failed", error });
+    } finally {
+      inFlight = false;
+    }
   };
 
   return {
     reset(day) {
       clearPending({ status: "superseded" });
       baseline = day;
+    },
+
+    flush() {
+      return runPending();
     },
 
     cancel() {
@@ -411,26 +468,9 @@ export function createLoggedDaySaver(
       clearPending({ status: "superseded" });
 
       return new Promise<SaveOutcome>((resolve) => {
-        supersede = resolve;
-        timer = setTimeout(async () => {
-          timer = null;
-          supersede = null;
-
-          if (inFlight) return resolve({ status: "superseded" });
-          if (baseline && baseline.date !== day.date) {
-            return resolve({ status: "wrong-day" });
-          }
-
-          inFlight = true;
-          try {
-            await saveLoggedDay(day);
-            if (baseline?.date === day.date) baseline = day;
-            resolve({ status: "saved", day });
-          } catch (error) {
-            resolve({ status: "failed", error });
-          } finally {
-            inFlight = false;
-          }
+        pending = { day, resolve };
+        timer = setTimeout(() => {
+          void runPending();
         }, delayMs);
       });
     },


### PR DESCRIPTION
Closes #214.

## Stacked on #212

**Base branch is `fix/162-flush-pending-save`, not `main`.** This touches the same function and the same test file as #212, so stacking is cheaper than resolving the same conflict twice. The other four PRs in this batch are independent and branch from `main`; this one does not. Merge #212 first, or the diff here will read as if it contains #212's changes too.

## The defect

`schedule()` returned `unchanged` **before** `clearPending`, so a pending write that the user had already reverted stayed armed and fired.

Reproduction, inside the 100ms debounce, on a day with no flow logged: select **Heavy**, then select **None** again. The second `schedule` compares against the baseline, sees nothing changed, returns early, and leaves the first one's timer running. The timer writes flow 3.

The database holds Heavy while the UI shows None, silently, because the save message renders from the in-memory snapshot rather than from a re-read.

## The fix

One line moved: `clearPending({ status: "superseded" })` now runs inside the `unchanged` branch before it returns.

## The asymmetry, which is the part that matters

The two early returns look alike and must not be treated alike. Both now carry a comment saying which way they go:

- **`unchanged`** disarms. It means there is nothing left to write, so a pending write is for a value the user has already abandoned.
- **`wrong-day`** does **not** disarm. A pending edit belongs to the day it was made against, and discarding it there is exactly the bug #162 fixed.

I did not want that resting on a comment, so both directions are pinned by tests, and I ran the mutation both ways to confirm they discriminate:

```
# removing the disarm from the `unchanged` branch
✕ disarms a pending write the user has backed out of
Tests:       1 failed, 30 passed, 31 total

# adding a disarm to the `wrong-day` branch
✕ still writes a pending edit for a day that is no longer open
Tests:       1 failed, 30 passed, 31 total
```

## Tests

Two added to `db/__tests__/loggedDay.test.ts`. The diff to that file is **purely additive** — no deleted lines — so #212's four tests are byte-for-byte unchanged and still pass, which is the signal the issue asked for.

- `disarms a pending write the user has backed out of` — the reported reproduction. It awaits the promise returned by the *first* `schedule`, not just `advanceTimersByTime`, because the write has not settled by the time the timer fires and asserting there reports a false pass. The stored-row assertion comes first so the failure names the harm:

  ```
  expect(received).toBeUndefined()
  Received: {"date": "2026-04-01", "flow_intensity": 3, ...}
  ```

- `still writes a pending edit for a day that is no longer open` — the other half of the asymmetry. It passed before this change, which is the point: it is there to stop the fix over-reaching.

## Known limit, stated rather than papered over

This clears a *timer*. It does not reach a write already **in flight**, where the debounce has elapsed and `saveLoggedDay` is midway through its queries. Reverting in that window still leaves the abandoned value written, until the next real edit or day-open corrects it. That is a much narrower race and needs a different answer than clearing a timer, so I left it alone rather than half-solving it here. Happy to file it if you want it tracked.

## Verification

```
$ npx eslint . --max-warnings=0
exit=0    (no output)

$ npm run typecheck
> ephira@1.3.0 typecheck
> tsc --noEmit
exit=0

$ npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       238 passed, 238 total
Snapshots:   0 total
Time:        2.582 s
exit=0

$ TZ=Europe/Brussels npm test -- --ci
Test Suites: 18 passed, 18 total
Tests:       238 passed, 238 total
Snapshots:   0 total
Time:        2.324 s
exit=0
```

236 on `fix/162-flush-pending-save`, 238 here: the two new tests.
