### PR TITLE
ci: run the checks on every pull request (#217)

### DIFF
--- a/.github/workflows/format-test.yml
+++ b/.github/workflows/format-test.yml
@@ -1,8 +1,15 @@
 name: Checks
 on:
+  # No `branches:` filter. That key filters on the PR's *base*, so a pull
+  # request stacked on another feature branch ran none of these checks and
+  # still reported green, because the Vercel checks do run. Green meaning
+  # "nothing was checked" is worse than red.
+  #
+  # `edited` is in the list because changing a PR's base fires that event and
+  # nothing else; without it, retargeting a PR to fix the above does not
+  # produce a run.
   pull_request:
-    branches:
-      - main
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   checks:

--- a/.github/workflows/manual-eas-build.yml
+++ b/.github/workflows/manual-eas-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
           cache: npm
 
       - name: Setup EAS


### PR DESCRIPTION
Closes #217.

## The gap

`.github/workflows/format-test.yml` filtered on `branches: [main]`. That key filters on the pull request's **base**, so any PR stacked on another feature branch ran no lint, no typecheck and no tests — and still showed all-green, because the Vercel checks are unaffected.

**This was live.** #215 sat green and completely ungated until it was retargeted.

Retargeting did not fix it either. With no `types:` given, `pull_request` defaults to `[opened, synchronize, reopened]`; changing a base fires `edited`, which is not in that list. #215 had to be closed and reopened to produce a run.

Both halves are fixed: the filter is gone, and `edited` is in the types list.

## Why no `branches:` filter at all rather than a longer list

The job is lint, typecheck and jest. There is no branch for which running those is wrong, and every filter is another chance to silently exclude something. If a protected-branch policy later needs the distinction, that is a reason to add a filter *then*, with the reason written down.

I did not add a `push:` trigger. It would gate work before a PR exists, but it doubles the runs on every PR branch — a separate decision, not an obvious yes.

## Also here

`manual-eas-build.yml` moves off **Node 18**, which is end of life. `format-test.yml` moved to 22 in #178; the build workflow was deliberately left alone then, because changing a release build's toolchain is a different risk from changing a CI checker's. It is bumped here on its own so it is a decision rather than a side effect of something else.

**Worth confirming before merge:** that an EAS production build still succeeds on Node 22. I cannot run one from here. If you would rather that half waited, say so and I will split it out.

## Verification

```
$ npx eslint . --max-warnings=0
ESLINT: 0
```

The real verification is this PR's own check run, and the next stacked PR anyone opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)