### PR TITLE
fix: date the prediction strip by the local day, and retire the offset hack (#206)

### DIFF
--- a/app/(pregnancy-tabs)/calendar.tsx
+++ b/app/(pregnancy-tabs)/calendar.tsx
@@ -26,6 +26,7 @@ import { AppointmentColor, SpecialtyFilterColor } from "@/constants/Colors";
 import FadeInView from "@/components/animations/FadeInView";
 import { useFocusEffect } from "expo-router";
 import PregnancyDayView from "@/components/pregnancyDayView/PregnancyDayView";
+import { formatAsISODate } from "@/utils/dates";
 
 const DEFAULT_FILTERS = ["Appointments", "Symptoms"];
 
@@ -39,10 +40,7 @@ export default function PregnancyCalendar() {
   const theme = useTheme();
   const styles = makeStyles({ theme });
 
-  const day = new Date();
-  const offset = day.getTimezoneOffset();
-  const localDate = new Date(day.getTime() - offset * 60 * 1000);
-  const today = localDate.toISOString().split("T")[0];
+  const today = formatAsISODate(new Date());
 
   const { themeColor } = useThemeColor();
   const themeKey = `${theme.dark ? "dark" : "light"}-${themeColor}`;

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -32,6 +32,7 @@ import {
   anyBirthControlOption,
 } from "@/constants/BirthControlTypes";
 import { useFocusEffect } from "expo-router";
+import { formatAsISODate } from "@/utils/dates";
 
 export default function FlowCalendar() {
   const [key, setKey] = useState<string>("");
@@ -47,11 +48,7 @@ export default function FlowCalendar() {
   const theme = useTheme();
   const styles = makeStyles({ theme });
 
-  // get date in local time
-  const day = new Date();
-  const offset = day.getTimezoneOffset();
-  const localDate = new Date(day.getTime() - offset * 60 * 1000);
-  const today = localDate.toISOString().split("T")[0];
+  const today = formatAsISODate(new Date());
 
   const dismissKeyboard = () => {
     Keyboard.dismiss();

--- a/components/cycle/PredictionCard.tsx
+++ b/components/cycle/PredictionCard.tsx
@@ -1,6 +1,31 @@
 import { View, StyleSheet } from "react-native";
 import { Card, Text, useTheme, MD3Theme } from "react-native-paper";
 import { PredictedDate } from "@/constants/Interfaces";
+import { addDays, formatAsISODate, startOfLocalDay } from "@/utils/dates";
+
+/**
+ * The seven days the strip shows, starting at `from`.
+ *
+ * Dated with `formatAsISODate`, which reads the local calendar day. This used
+ * `toISOString`, which is UTC: east of UTC every date in the strip was
+ * labelled a day early, so the "today" marker sat on the wrong column and
+ * each column matched a prediction belonging to the day before it.
+ *
+ * `from` is a parameter rather than a clock read, which is what lets this be
+ * tested in both directions without pinning a timezone.
+ */
+export function upcomingWeek(from: Date) {
+  const start = startOfLocalDay(from);
+
+  return Array.from({ length: 7 }, (_, offset) => {
+    const date = addDays(start, offset);
+    return {
+      dateStr: formatAsISODate(date),
+      dayNum: date.getDate(),
+      weekday: date.toLocaleDateString("en-US", { weekday: "short" }).charAt(0),
+    };
+  });
+}
 
 interface PredictionCardProps {
   daysUntilNextPeriod: number;
@@ -16,19 +41,8 @@ function MiniCalendar({
   predictedDates: PredictedDate[];
   theme: MD3Theme;
 }) {
-  const today = new Date();
-  const todayStr = today.toISOString().split("T")[0];
-
-  // Show next 7 days
-  const days = Array.from({ length: 7 }, (_, i) => {
-    const date = new Date(today);
-    date.setDate(date.getDate() + i);
-    return {
-      dateStr: date.toISOString().split("T")[0],
-      dayNum: date.getDate(),
-      weekday: date.toLocaleDateString("en-US", { weekday: "short" }).charAt(0),
-    };
-  });
+  const days = upcomingWeek(new Date());
+  const todayStr = days[0].dateStr;
 
   const predictedSet = new Set(predictedDates.map((p) => p.date));
 

--- a/components/cycle/__tests__/PredictionCard.test.ts
+++ b/components/cycle/__tests__/PredictionCard.test.ts
@@ -1,0 +1,76 @@
+import { upcomingWeek } from "@/components/cycle/PredictionCard";
+
+// The card renders react-native-paper; the day arithmetic does not.
+jest.mock("@/db/operations/setup", () => ({
+  getDatabase: jest.fn(),
+  getDrizzleDatabase: jest.fn(),
+}));
+
+describe("upcomingWeek", () => {
+  it("returns seven days starting at the reference day", () => {
+    const week = upcomingWeek(new Date(2026, 4, 4, 9, 0));
+
+    expect(week).toHaveLength(7);
+    expect(week.map((d) => d.dateStr)).toEqual([
+      "2026-05-04",
+      "2026-05-05",
+      "2026-05-06",
+      "2026-05-07",
+      "2026-05-08",
+      "2026-05-09",
+      "2026-05-10",
+    ]);
+  });
+
+  it("dates the strip by the local calendar day, not by UTC", () => {
+    // Half past midnight local is the *previous* day in UTC for anyone east
+    // of it. Formatting with toISOString labelled the whole strip a day early
+    // for those users, and matched predictions to the wrong column.
+    expect(upcomingWeek(new Date(2026, 4, 2, 0, 30))[0].dateStr).toBe(
+      "2026-05-02",
+    );
+
+    // And half past eleven at night is the *next* day in UTC for anyone west
+    // of it. Both directions, so this test fails in some timezone if the
+    // implementation ever goes back to UTC.
+    expect(upcomingWeek(new Date(2026, 4, 1, 23, 30))[0].dateStr).toBe(
+      "2026-05-01",
+    );
+  });
+
+  it("carries the day number that matches its date string", () => {
+    for (const day of upcomingWeek(new Date(2026, 4, 4))) {
+      expect(day.dayNum).toBe(Number(day.dateStr.split("-")[2]));
+    }
+  });
+
+  it("crosses a month boundary", () => {
+    expect(upcomingWeek(new Date(2026, 4, 29)).map((d) => d.dateStr)).toEqual([
+      "2026-05-29",
+      "2026-05-30",
+      "2026-05-31",
+      "2026-06-01",
+      "2026-06-02",
+      "2026-06-03",
+      "2026-06-04",
+    ]);
+  });
+
+  it("stays on calendar days across a daylight saving transition", () => {
+    // Spring forward is 2026-03-29 in Europe, 2026-03-08 in the US. A
+    // millisecond-based step lands on the wrong day for one of them.
+    const march = upcomingWeek(new Date(2026, 2, 6)).map((d) => d.dateStr);
+    expect(march[2]).toBe("2026-03-08");
+    expect(march[6]).toBe("2026-03-12");
+
+    const late = upcomingWeek(new Date(2026, 2, 27)).map((d) => d.dateStr);
+    expect(late[2]).toBe("2026-03-29");
+    expect(late[6]).toBe("2026-04-02");
+  });
+
+  it("gives each day a single-letter weekday", () => {
+    for (const day of upcomingWeek(new Date(2026, 4, 4))) {
+      expect(day.weekday).toHaveLength(1);
+    }
+  });
+});

--- a/db/__tests__/predictionSnapshots.test.ts
+++ b/db/__tests__/predictionSnapshots.test.ts
@@ -13,10 +13,13 @@ jest.mock("@/db/operations/setup", () =>
   jest.requireActual("@/__tests__/helpers/testDatabase"),
 );
 
-// UTC, because savePredictions formats with toISOString, matching the
-// convention services/cyclePredictionLogic.ts already uses for date strings.
-const MARCH_1 = new Date("2026-03-01T00:00:00Z");
-const MARCH_2 = new Date("2026-03-02T00:00:00Z");
+// Local, because savePredictions formats the reference day with
+// formatAsISODate. These were UTC instants when this file was written, which
+// name the previous day everywhere west of UTC: midnight UTC on the 1st is
+// 16:00 on the 28th in Los Angeles, so the assertions below failed for half
+// the world while passing in CI.
+const MARCH_1 = new Date(2026, 2, 1);
+const MARCH_2 = new Date(2026, 2, 2);
 
 const storedSnapshots = () =>
   getTestDatabase()

--- a/db/quickBirthControl.ts
+++ b/db/quickBirthControl.ts
@@ -7,15 +7,11 @@ import { getMedication } from "@/db/operations/medications";
 import { getSetting } from "@/db/operations/settings";
 import { SettingsKeys } from "@/constants/Settings";
 import { birthControlOptions } from "@/constants/BirthControlTypes";
+import { formatAsISODate } from "@/utils/dates";
 
 export const LONG_TERM_BC_TYPES = ["IUD", "Implant"];
 
-const todayISO = () => {
-  const day = new Date();
-  const offset = day.getTimezoneOffset();
-  const localDate = new Date(day.getTime() - offset * 60 * 1000);
-  return localDate.toISOString().slice(0, 10);
-};
+const todayISO = () => formatAsISODate(new Date());
 
 // get the user's configured BC type from settings, or null if none set
 export async function getActiveBirthControlType(): Promise<string | null> {

--- a/hooks/useMarkedDates.ts
+++ b/hooks/useMarkedDates.ts
@@ -22,7 +22,7 @@ import { anyMoodOption } from "@/constants/Moods";
 import { anyMedicationOption } from "@/constants/Medications";
 import { anyBirthControlOption } from "@/constants/BirthControlTypes";
 import { refreshPredictions } from "@/services/cyclePredictions";
-import { startOfLocalDay } from "@/utils/dates";
+import { startOfLocalDay, formatAsISODate } from "@/utils/dates";
 
 function getStartingAndEndingDay(
   day: string,
@@ -338,11 +338,7 @@ export function useMarkedDates(calendarFilters?: string[]) {
   // identity to hold in a ref the way the hook it replaced needed.
   const referenceDay = useMemo(() => startOfLocalDay(), []);
 
-  // get date in local time
-  const day = new Date();
-  const offset = day.getTimezoneOffset();
-  const localDate = new Date(day.getTime() - offset * 60 * 1000);
-  const today = localDate.toISOString().split("T")[0];
+  const today = formatAsISODate(new Date());
 
   // useLiveQuery will automatically update the calendar when the db data changes
   useEffect(() => {


### PR DESCRIPTION
Closes #206. Finishes the timezone pattern — this was the fourth and last instance.

## The defect

`components/cycle/PredictionCard.tsx` built its seven-day strip with `toISOString()` and, unlike its three siblings, had **no offset shift in front of it**. East of UTC every date in the strip was labelled a day early: the "today" marker sat on the wrong column, and each column matched a prediction belonging to the day before it.

The arithmetic is now an exported `upcomingWeek(from)` taking its reference day as a parameter, so it is testable in both directions without pinning a timezone:

```
✓ returns seven days starting at the reference day
✓ dates the strip by the local calendar day, not by UTC
✓ carries the day number that matches its date string
✓ crosses a month boundary
✓ stays on calendar days across a daylight saving transition
✓ gives each day a single-letter weekday
```

The second test asserts both directions at once — 00:30 local is the previous day in UTC for anyone east, 23:30 is the next day for anyone west. One implementation has to satisfy both, so the test fails *somewhere* if this ever regresses.

## The three that were right by accident

`app/(tabs)/calendar.tsx`, `app/(pregnancy-tabs)/calendar.tsx`, `hooks/useMarkedDates.ts` and `db/quickBirthControl.ts` all did this:

```ts
const day = new Date();
const offset = day.getTimezoneOffset();
const localDate = new Date(day.getTime() - offset * 60 * 1000);
const today = localDate.toISOString().split("T")[0];
```

Correct, but by construction rather than by meaning — shift the clock so that formatting it as UTC happens to yield the local day. All four now call `formatAsISODate`. **There is no `getTimezoneOffset` left in the repo**, and one way to turn a `Date` into a day string.

## A pre-existing test defect this surfaced

Sweeping five timezones instead of two turned up two assertions in `db/__tests__/predictionSnapshots.test.ts` failing in **every negative-offset timezone**, and failing on `main` before this branch:

```
- Expected  "2026-03-01"
+ Received  "2026-02-28"
```

That one is mine, from #187: I changed `savePredictions` to format locally and left the test's reference dates as UTC instants. Midnight UTC on the 1st is 16:00 on the 28th in Los Angeles. It passes in CI because **CI runs in UTC**, which is the whole reason this class of bug keeps surviving here.

Fixed by making the constants local, with a comment saying why. I folded it in rather than filing it, because this PR claims cross-timezone verification and that claim would be false while two known failures stood.

## Verification

```
$ npx eslint . --max-warnings=0     → 0
$ npm run typecheck                 → 0

$ TZ=<zone> npm test -- --ci
UTC                    Tests: 246 passed, 246 total
Europe/Brussels        Tests: 246 passed, 246 total
America/Los_Angeles    Tests: 246 passed, 246 total
Pacific/Auckland       Tests: 246 passed, 246 total
Asia/Kolkata           Tests: 246 passed, 246 total
```

Five zones deliberately: two east, one west, one far east, and one on a half-hour offset.

**Worth considering separately:** CI still only runs in UTC, so it cannot catch this class at all. A matrix over two or three zones on the test job would close that. I have not done it here — it is a CI change and #217 is already in flight touching that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)