### PR TITLE
fix: hydrate durable preferences in the shell, not on the calendar screen (#210)

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   StyleSheet,
   View,
@@ -12,7 +12,6 @@ import {
 } from "react-native";
 import { Calendar } from "react-native-calendars";
 import { SafeAreaView, SafeAreaProvider } from "react-native-safe-area-context";
-import { SettingsKeys } from "@/constants/Settings";
 import DayView from "@/components/dayView/DayView";
 import { useTheme, MD3Theme, Divider, Text } from "react-native-paper";
 import {
@@ -21,7 +20,6 @@ import {
   useThemeColor,
   usePredictionChoice,
 } from "@/stores/calendar-storage";
-import { getSetting, insertSetting } from "@/db/database";
 import CalendarHeader from "@/components/calendar/CalendarHeader";
 import CustomDay from "@/components/calendar/CustomDay";
 import { useMarkedDates } from "@/hooks/useMarkedDates";
@@ -38,8 +36,8 @@ export default function FlowCalendar() {
 
   // access state management
   const { date, setDate } = useSelectedDate();
-  const { selectedFilters, setSelectedFilters } = useCalendarFilters();
-  const { predictionChoice, setPredictionChoice } = usePredictionChoice();
+  const { selectedFilters } = useCalendarFilters();
+  const { predictionChoice } = usePredictionChoice();
   // can also be used like this
   // const selectedDate = useSelectedDate().date
 
@@ -59,42 +57,6 @@ export default function FlowCalendar() {
 
   const { themeColor } = useThemeColor();
   const themeKey = `${theme.dark ? "dark" : "light"}-${themeColor}`;
-
-  // load filters from secure store
-  useEffect(() => {
-    const loadFilters = async () => {
-      const filters = await getSetting(SettingsKeys.calendarFilters);
-      if (filters?.value) {
-        setSelectedFilters(JSON.parse(filters.value));
-      } else {
-        // set Flow and Any Birth Control as default filters
-        setSelectedFilters(["Flow", "Any Birth Control"]);
-        await insertSetting(
-          SettingsKeys.calendarFilters,
-          JSON.stringify(["Flow", "Any Birth Control"]),
-        );
-      }
-    };
-    loadFilters();
-  }, [setSelectedFilters]);
-
-  // load filters from secure store
-  useEffect(() => {
-    const loadPredictionChoice = async () => {
-      const filters = await getSetting(SettingsKeys.cyclePredictions);
-      if (filters?.value) {
-        setPredictionChoice(JSON.parse(filters.value));
-      } else {
-        // set Flow as first filter by default (filler color given since color isn't optional)
-        setPredictionChoice(true);
-        await insertSetting(
-          SettingsKeys.cyclePredictions,
-          JSON.stringify(true),
-        );
-      }
-    };
-    loadPredictionChoice();
-  }, [setPredictionChoice]);
 
   // Set selected date to today when screen is focused
   useFocusEffect(

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -38,7 +38,16 @@ import {
 import DatabaseMigrationError from "@/components/DatabaseMigrationError";
 import PasswordAuthenticationView from "@/components/PasswordAuthenticationView";
 import { getTheme } from "@/components/ThemeHandler";
-import { useThemeColor, useTrackingMode } from "@/stores/calendar-storage";
+import {
+  useCalendarFilters,
+  usePredictionChoice,
+  useThemeColor,
+  useTrackingMode,
+} from "@/stores/calendar-storage";
+import {
+  loadCalendarFilters,
+  loadCyclePredictionChoice,
+} from "@/db/preferences";
 import * as Notifications from "expo-notifications";
 import { NotificationTypes } from "@/constants/Notifications";
 
@@ -49,6 +58,8 @@ export default function RootLayout() {
   const isDarkMode = systemTheme === "dark";
   const { themeColor, setThemeColor } = useThemeColor();
   const { setTrackingMode } = useTrackingMode();
+  const { setPredictionChoice } = usePredictionChoice();
+  const { setSelectedFilters } = useCalendarFilters();
 
   useEffect(() => {
     async function fetchThemeColor() {
@@ -69,6 +80,18 @@ export default function RootLayout() {
     }
     fetchTrackingMode();
   }, [setTrackingMode]);
+
+  // Durable preferences hydrate in the shell, not on the screen that happens
+  // to need them first. These were loaded by the Calendar tab, so any screen
+  // reached before it read a store still holding its initial value: the Cycle
+  // tab told users predictions were off when their setting said on.
+  useEffect(() => {
+    loadCyclePredictionChoice().then(setPredictionChoice);
+  }, [setPredictionChoice]);
+
+  useEffect(() => {
+    loadCalendarFilters().then(setSelectedFilters);
+  }, [setSelectedFilters]);
 
   const finalSelectedColor = themeColor as
     | "blue"

--- a/db/__tests__/preferences.test.ts
+++ b/db/__tests__/preferences.test.ts
@@ -1,0 +1,82 @@
+import {
+  DEFAULT_CALENDAR_FILTERS,
+  loadCalendarFilters,
+  loadCyclePredictionChoice,
+} from "@/db/preferences";
+import { getSetting, insertSetting } from "@/db/operations/settings";
+import { SettingsKeys } from "@/constants/Settings";
+import { resetTestDatabase } from "@/__tests__/helpers/testDatabase";
+
+jest.mock("@/db/operations/setup", () =>
+  jest.requireActual("@/__tests__/helpers/testDatabase"),
+);
+
+beforeEach(() => {
+  resetTestDatabase();
+});
+
+describe("loadCyclePredictionChoice", () => {
+  it("returns what the user chose", async () => {
+    await insertSetting(SettingsKeys.cyclePredictions, JSON.stringify(false));
+
+    expect(await loadCyclePredictionChoice()).toBe(false);
+  });
+
+  it("defaults to on for a user who has never chosen", async () => {
+    expect(await loadCyclePredictionChoice()).toBe(true);
+  });
+
+  it("writes the default down, so it is a choice on record", async () => {
+    await loadCyclePredictionChoice();
+
+    expect((await getSetting(SettingsKeys.cyclePredictions))?.value).toBe(
+      JSON.stringify(true),
+    );
+  });
+
+  it("does not overwrite an existing choice with the default", async () => {
+    await insertSetting(SettingsKeys.cyclePredictions, JSON.stringify(false));
+
+    await loadCyclePredictionChoice();
+
+    expect((await getSetting(SettingsKeys.cyclePredictions))?.value).toBe(
+      JSON.stringify(false),
+    );
+  });
+
+  it("falls back to the default rather than throwing on a corrupt value", async () => {
+    await insertSetting(SettingsKeys.cyclePredictions, "not json");
+
+    expect(await loadCyclePredictionChoice()).toBe(true);
+  });
+});
+
+describe("loadCalendarFilters", () => {
+  it("returns what the user chose", async () => {
+    await insertSetting(
+      SettingsKeys.calendarFilters,
+      JSON.stringify(["Flow", "Moods"]),
+    );
+
+    expect(await loadCalendarFilters()).toEqual(["Flow", "Moods"]);
+  });
+
+  it("defaults for a user who has never chosen, and writes it down", async () => {
+    expect(await loadCalendarFilters()).toEqual([...DEFAULT_CALENDAR_FILTERS]);
+    expect((await getSetting(SettingsKeys.calendarFilters))?.value).toBe(
+      JSON.stringify(DEFAULT_CALENDAR_FILTERS),
+    );
+  });
+
+  it("keeps an empty selection, which is a choice and not an absence", async () => {
+    await insertSetting(SettingsKeys.calendarFilters, JSON.stringify([]));
+
+    expect(await loadCalendarFilters()).toEqual([]);
+  });
+
+  it("falls back to the default rather than throwing on a corrupt value", async () => {
+    await insertSetting(SettingsKeys.calendarFilters, "{not json");
+
+    expect(await loadCalendarFilters()).toEqual([...DEFAULT_CALENDAR_FILTERS]);
+  });
+});

--- a/db/preferences.ts
+++ b/db/preferences.ts
@@ -1,0 +1,67 @@
+import { getSetting, insertSetting } from "@/db/operations/settings";
+import { SettingsKeys } from "@/constants/Settings";
+
+/**
+ * Durable preferences, with their defaults.
+ *
+ * These loaders exist because a Zustand store's initial value is a lie until
+ * something hydrates it, and a store that is only hydrated by one screen is
+ * not safe to read from any other. `predictionChoice` initialised to `false`
+ * and was loaded by the Calendar tab alone, so a user who cold-started into
+ * the Cycle tab was told predictions were off while their stored setting said
+ * on. Hydration belongs in the app shell; the default belongs here, where it
+ * can be tested.
+ */
+
+/** Predictions are on unless the user has turned them off. */
+export const DEFAULT_CYCLE_PREDICTION_CHOICE = true;
+
+/** What a new user sees on the calendar before they choose. */
+export const DEFAULT_CALENDAR_FILTERS = ["Flow", "Any Birth Control"] as const;
+
+/**
+ * Reads a stored JSON setting, writing the default down if there is none.
+ *
+ * A default that is never persisted is not a choice on record: every read has
+ * to re-derive it, and two readers can disagree about what it is.
+ *
+ * A stored value that will not parse falls back to the default rather than
+ * throwing. It is a corrupt preference, not a reason to fail a screen, and
+ * the previous inline versions of this would have rejected inside an effect.
+ */
+async function loadJsonSetting<T>(
+  key: string,
+  fallback: T,
+  isValid: (value: unknown) => value is T,
+): Promise<T> {
+  const stored = await getSetting(key);
+
+  if (stored?.value !== undefined && stored?.value !== null) {
+    try {
+      const parsed: unknown = JSON.parse(stored.value);
+      if (isValid(parsed)) return parsed;
+    } catch {
+      // fall through to the default
+    }
+  }
+
+  await insertSetting(key, JSON.stringify(fallback));
+  return fallback;
+}
+
+export function loadCyclePredictionChoice(): Promise<boolean> {
+  return loadJsonSetting(
+    SettingsKeys.cyclePredictions,
+    DEFAULT_CYCLE_PREDICTION_CHOICE,
+    (value): value is boolean => typeof value === "boolean",
+  );
+}
+
+export function loadCalendarFilters(): Promise<string[]> {
+  return loadJsonSetting<string[]>(
+    SettingsKeys.calendarFilters,
+    [...DEFAULT_CALENDAR_FILTERS],
+    (value): value is string[] =>
+      Array.isArray(value) && value.every((item) => typeof item === "string"),
+  );
+}


### PR DESCRIPTION
Closes #210.

## The defect

`usePredictionChoice` initialises to `false` and was hydrated in exactly one place — an effect on the Calendar tab. Home is the initial route and tabs mount lazily, so **any screen reached before the calendar reads a store still holding its initial value**.

`app/(tabs)/cycle.tsx:154` is where it shows: cold-start into the Cycle tab and a user whose stored setting says predictions are on is told they are disabled.

## `useCalendarFilters` had it too

The issue asked me to look. It has the same shape and the same exposure: read by `EntryVisibilitySettings`, `CyclePrediction` and `CustomEntries`, all reachable from the Settings tab without the calendar ever mounting, where it reads as an empty selection.

I moved both. The general shape is worth naming: **a Zustand store whose initial value is a lie until one particular screen mounts is not safe to read from any other screen.** Those two were the only ones in `stores/calendar-storage.tsx` loaded that way; `themeColor` and `trackingMode` already hydrate in the shell, which is the pattern this follows.

## Shape

`db/preferences.ts` owns the loaders and their defaults, so both are testable:

```
✓ returns what the user chose
✓ defaults to on for a user who has never chosen
✓ writes the default down, so it is a choice on record
✓ does not overwrite an existing choice with the default
✓ falls back to the default rather than throwing on a corrupt value
✓ keeps an empty selection, which is a choice and not an absence
```

Persisting the default on first read is kept from the inline versions. A default that is never written down is not a choice on record, and two readers can disagree about what it is.

## One behaviour change

A stored value that will not parse now falls back to the default instead of throwing. The inline versions called `JSON.parse` unguarded, so a corrupt preference rejected inside an effect. Deliberate, and covered by a test.

## Not in scope

Whether the home screen should consult `predictionChoice` now that it is trustworthy. That is a product question, and #211 deliberately gated on `hasEnoughData` only because of this defect. Worth revisiting now that the ground is solid — but as its own decision.

## Verification

```
$ npx eslint . --max-warnings=0     → 0
$ npm run typecheck                 → 0
$ TZ=UTC npm test -- --ci           → Tests: 249 passed, 249 total
```

`TZ=America/Los_Angeles` shows **2 pre-existing failures** on this branch, in `db/__tests__/predictionSnapshots.test.ts`. They are not from this change — they fail on `main` too, and they are fixed in #223. Merge that first and this is clean in every timezone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)