### PR TITLE
fix: converge on the last edit when a revert lands mid-write (#216)

### DIFF
--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -427,6 +427,56 @@ describe("the saver's timing rules", () => {
     expect(await getDay(DATE)).toBeUndefined();
   });
 
+  it("corrects a revert that lands while the save is already running", async () => {
+    // Narrower than the debounce window #214 closed: the timer has fired and
+    // saveLoggedDay is midway through its queries, so there is no timer left
+    // to disarm. The write still has to converge on what the user last chose.
+    const saver = createLoggedDaySaver();
+    const baseline = { ...emptyLoggedDay(DATE), flow: 0 };
+    await saveLoggedDay(baseline);
+    saver.reset(baseline);
+
+    const heavy = saver.schedule({ ...baseline, flow: 3 });
+    jest.advanceTimersByTime(100); // the write starts and suspends
+    const reverted = saver.schedule(baseline); // user backs out mid-write
+
+    await heavy; // the user's own write landed
+    await saver.settled(); // and then the day stopped changing
+
+    expect((await getDay(DATE))?.flow_intensity).toBe(0);
+    expect((await reverted).status).toBe("unchanged");
+  });
+
+  it("does not drop a different edit made while the save is running", async () => {
+    const saver = createLoggedDaySaver();
+    const baseline = { ...emptyLoggedDay(DATE), flow: 0 };
+    await saveLoggedDay(baseline);
+    saver.reset(baseline);
+
+    const first = saver.schedule({ ...baseline, flow: 1 });
+    jest.advanceTimersByTime(100); // the write starts and suspends
+    saver.schedule({ ...baseline, flow: 4 }); // a second edit lands inside it
+
+    await first;
+    await saver.settled();
+
+    // The second edit's own debounce is still armed and never awaited: the
+    // convergence pass after the first write already wrote what it asked for.
+    expect((await getDay(DATE))?.flow_intensity).toBe(4);
+  });
+
+  it("writes once when nothing follows the save", async () => {
+    const saver = createLoggedDaySaver();
+    const baseline = { ...emptyLoggedDay(DATE), flow: 0 };
+    saver.reset(baseline);
+
+    const only = saver.schedule({ ...baseline, flow: 2 });
+    jest.advanceTimersByTime(100);
+
+    expect((await only).status).toBe("saved");
+    expect((await getDay(DATE))?.flow_intensity).toBe(2);
+  });
+
   it("reports a failure rather than throwing at the caller", async () => {
     const saver = createLoggedDaySaver();
     saver.reset(emptyLoggedDay(DATE));

--- a/db/loggedDay.ts
+++ b/db/loggedDay.ts
@@ -363,6 +363,15 @@ export type LoggedDaySaver = {
   flush(): Promise<SaveOutcome>;
   /** Discards a pending edit. For teardown that should not write. */
   cancel(): void;
+  /**
+   * Resolves when no write is outstanding, convergence included.
+   *
+   * `schedule` resolves as soon as the caller's own snapshot has been
+   * written, which is what a save message wants. That is not the same moment
+   * the day stops changing, because a revert arriving mid-write triggers a
+   * further pass. Anything that needs the settled state waits on this.
+   */
+  settled(): Promise<void>;
 };
 
 export const DEFAULT_SAVE_DELAY_MS = 100;
@@ -395,12 +404,17 @@ export function createLoggedDaySaver(
   const delayMs = options.delayMs ?? DEFAULT_SAVE_DELAY_MS;
 
   let baseline: LoggedDay | null = null;
+  // The last snapshot the caller reported, whatever came of it. Kept even for
+  // calls that write nothing, because a revert arriving mid-write is exactly
+  // the case that has no pending timer left to disarm.
+  let desired: LoggedDay | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let pending: {
     day: LoggedDay;
     resolve: (outcome: SaveOutcome) => void;
   } | null = null;
   let inFlight = false;
+  let running: Promise<unknown> = Promise.resolve();
 
   const takePending = () => {
     if (timer) clearTimeout(timer);
@@ -419,6 +433,41 @@ export function createLoggedDaySaver(
    * now. Resolves whoever called `schedule` and returns the same outcome to
    * whoever asked for the flush.
    */
+  /** Writes `day`, moving the baseline with it if that day is still open. */
+  const write = async (day: LoggedDay) => {
+    inFlight = true;
+    try {
+      await saveLoggedDay(day);
+      if (baseline?.date === day.date) baseline = day;
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  /**
+   * Converges on what the caller last asked for.
+   *
+   * A save takes long enough for the user to change their mind inside it, and
+   * once it has started there is no timer to disarm. Rather than queueing,
+   * which needs its own ordering rules, each completed write checks whether
+   * the answer has moved and writes again if it has. It terminates because
+   * every pass sets the baseline to what it just wrote.
+   */
+  const converge = async () => {
+    while (
+      desired &&
+      baseline &&
+      desired.date === baseline.date &&
+      loggedDayChanged(desired, baseline)
+    ) {
+      try {
+        await write(desired);
+      } catch {
+        return; // the next edit or day-open corrects it
+      }
+    }
+  };
+
   const runPending = async (): Promise<SaveOutcome> => {
     const taken = takePending();
     if (!taken) return { status: "unchanged" };
@@ -434,26 +483,31 @@ export function createLoggedDaySaver(
       return settle({ status: "wrong-day" });
     }
 
-    inFlight = true;
     try {
-      await saveLoggedDay(day);
-      if (baseline?.date === day.date) baseline = day;
-      return settle({ status: "saved", day });
+      await write(day);
     } catch (error) {
       return settle({ status: "failed", error });
-    } finally {
-      inFlight = false;
     }
+
+    const outcome = settle({ status: "saved", day });
+    await converge();
+    return outcome;
   };
 
   return {
     reset(day) {
       clearPending({ status: "superseded" });
       baseline = day;
+      desired = day;
     },
 
     flush() {
-      return runPending();
+      running = runPending();
+      return running as Promise<SaveOutcome>;
+    },
+
+    settled() {
+      return running.then(() => undefined);
     },
 
     cancel() {
@@ -471,6 +525,8 @@ export function createLoggedDaySaver(
       // Disarms, because this one means there is nothing left to write. The
       // user backed out of an edit inside the debounce, so any pending write
       // is now for a value they have already abandoned (#214).
+      desired = day;
+
       if (baseline && !loggedDayChanged(day, baseline)) {
         clearPending({ status: "superseded" });
         return Promise.resolve({ status: "unchanged" as const });
@@ -481,7 +537,8 @@ export function createLoggedDaySaver(
       return new Promise<SaveOutcome>((resolve) => {
         pending = { day, resolve };
         timer = setTimeout(() => {
-          void runPending();
+          running = runPending();
+          void running;
         }, delayMs);
       });
     },


### PR DESCRIPTION
Closes #216. The residual #215 named and stopped short of.

## The window

#214 disarmed a pending write the user had backed out of. That clears a **timer** — it cannot reach a write that has already started. Once the debounce has elapsed and `saveLoggedDay` is midway through its queries, a revert returns `unchanged` (correctly — the snapshot does match the baseline the saver still holds) and nothing rewrites the abandoned value.

The row kept the value the user backed out of until the next edit or day-open corrected it.

## The fix, and the option I did not take

The saver now remembers what the caller last asked for — including calls that write nothing, which is the whole point, since a mid-write revert leaves no timer behind. Each completed write checks whether that answer has moved and writes again if it has. It terminates because every pass sets the baseline to what it just wrote.

The same pass closes the other loss in that window: an edit scheduled *while* a save is running was dropped as `superseded` if the save outlasted the debounce.

**Queueing** was the alternative I floated in the issue. It needs its own ordering rules and changes what `superseded` means to existing callers. Converging after the fact needs neither and reaches the same state.

```
✓ corrects a revert that lands while the save is already running
✓ does not drop a different edit made while the save is running
✓ writes once when nothing follows the save
```

All 31 existing tests pass untouched, including #212's flush rules and #215's asymmetry pair.

## `settled()` — flagging this one

Writing the tests surfaced a distinction the interface did not express: `schedule()` resolves as soon as **the caller's own snapshot** is written, which is what a save message wants, and that is deliberately not the moment **the day stops changing**.

`settled()` resolves at the second. It is real and worth naming, but I should be straight with you: **it has no production caller yet.** `DayView`'s cleanup cannot await anything. If you would rather not carry an API that only tests use, say so and I will inline the wait in the tests instead — the two are equivalent, I just think the distinction deserves a name.

## One known minor

After a convergence pass, `DayView`'s `lastSaved` holds the snapshot from the *first* write rather than the converged one, because it is set from `schedule`'s outcome. It affects only which section the next "Saved!" message names, and only in this narrow window. Correcting it means `DayView` reading the settled state rather than the outcome, which is more churn than the symptom justifies. Noting rather than hiding it.

## Verification

```
$ npx eslint . --max-warnings=0     → 0
$ npm run typecheck                 → 0
$ TZ=UTC             npm test --ci  → Tests: 243 passed, 243 total
$ TZ=Europe/Brussels npm test --ci  → Tests: 243 passed, 243 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)