### PR TITLE
refactor: take the accuracy check's date as a parameter (#218)

### DIFF
--- a/components/dayView/DayView.tsx
+++ b/components/dayView/DayView.tsx
@@ -78,7 +78,7 @@ export default function DayView() {
   const [saveMessageContent, setSaveMessageContent] = useState<string[]>([]);
 
   // Everything about when and how a day is written lives in db/loggedDay.ts.
-  const saver = useRef(createLoggedDaySaver()).current;
+  const saver = useRef(createLoggedDaySaver({ now: () => new Date() })).current;
   const [lastSaved, setLastSaved] = useState<LoggedDay | null>(null);
   const loaded = useRef(false);
 

--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -26,6 +26,9 @@ jest.mock("@/db/operations/setup", () =>
 );
 
 const DATE = "2026-04-01";
+
+/** Fixed "today" for the prediction accuracy check these writes trigger. */
+const CHECKED_ON = new Date(2026, 3, 1);
 const OTHER_DATE = "2026-04-02";
 
 const aDay = (overrides: Partial<LoggedDay> = {}): LoggedDay => ({
@@ -42,7 +45,7 @@ describe("saveLoggedDay", () => {
   it("creates the Day row before writing its entries", async () => {
     // The rule stated three times with two different answers: quickBirthControl
     // creates a missing Day, the sync hooks silently returned. One answer now.
-    await saveLoggedDay(aDay({ moods: ["Calm"] }));
+    await saveLoggedDay(aDay({ moods: ["Calm"] }), CHECKED_ON);
 
     const day = await getDay(DATE);
     expect(day).toBeTruthy();
@@ -58,6 +61,7 @@ describe("saveLoggedDay", () => {
         isCycleEnd: false,
         intercourse: true,
       }),
+      CHECKED_ON,
     );
 
     expect(await getDay(DATE)).toMatchObject({
@@ -70,7 +74,7 @@ describe("saveLoggedDay", () => {
   });
 
   it("adds catalogue items it has never seen", async () => {
-    await saveLoggedDay(aDay({ symptoms: ["Aura"] }));
+    await saveLoggedDay(aDay({ symptoms: ["Aura"] }), CHECKED_ON);
 
     expect(
       getTestDatabase()
@@ -84,14 +88,14 @@ describe("saveLoggedDay", () => {
   it("reuses a catalogue item that already exists", async () => {
     getTestDatabase().insert(moods).values({ name: "Calm" }).run();
 
-    await saveLoggedDay(aDay({ moods: ["Calm"] }));
+    await saveLoggedDay(aDay({ moods: ["Calm"] }), CHECKED_ON);
 
     expect(getTestDatabase().select().from(moods).all()).toHaveLength(1);
   });
 
   it("removes entries the user has deselected", async () => {
-    await saveLoggedDay(aDay({ symptoms: ["Cramps", "Nausea"] }));
-    await saveLoggedDay(aDay({ symptoms: ["Cramps"] }));
+    await saveLoggedDay(aDay({ symptoms: ["Cramps", "Nausea"] }), CHECKED_ON);
+    await saveLoggedDay(aDay({ symptoms: ["Cramps"] }), CHECKED_ON);
 
     expect(getTestDatabase().select().from(symptomEntries).all()).toHaveLength(
       1,
@@ -105,10 +109,10 @@ describe("saveLoggedDay", () => {
       medications: [{ name: "Ibuprofen" }],
     });
 
-    await saveLoggedDay(day);
+    await saveLoggedDay(day, CHECKED_ON);
     const first = getTestDatabase().select().from(symptomEntries).all();
 
-    await saveLoggedDay(day);
+    await saveLoggedDay(day, CHECKED_ON);
 
     expect(getTestDatabase().select().from(symptomEntries).all()).toEqual(
       first,
@@ -126,6 +130,7 @@ describe("saveLoggedDay", () => {
           { name: "Pill", timeTaken: "08:00", notes: "with breakfast" },
         ],
       }),
+      CHECKED_ON,
     );
 
     expect(
@@ -136,9 +141,11 @@ describe("saveLoggedDay", () => {
   it("updates per-entry detail in place rather than duplicating", async () => {
     await saveLoggedDay(
       aDay({ medications: [{ name: "Pill", timeTaken: "08:00" }] }),
+      CHECKED_ON,
     );
     await saveLoggedDay(
       aDay({ medications: [{ name: "Pill", timeTaken: "21:00" }] }),
+      CHECKED_ON,
     );
 
     const entries = getTestDatabase().select().from(medicationEntries).all();
@@ -149,7 +156,10 @@ describe("saveLoggedDay", () => {
   it("leaves no entry pointing at a catalogue item that is gone", async () => {
     // Foreign keys are on in tests, so an ordering mistake fails loudly here.
     await expect(
-      saveLoggedDay(aDay({ moods: ["Calm"], symptoms: ["Cramps"] })),
+      saveLoggedDay(
+        aDay({ moods: ["Calm"], symptoms: ["Cramps"] }),
+        CHECKED_ON,
+      ),
     ).resolves.not.toThrow();
   });
 });
@@ -170,7 +180,7 @@ describe("loadLoggedDay", () => {
       medications: [{ name: "Pill", timeTaken: "08:00", notes: "am" }],
     });
 
-    await saveLoggedDay(day);
+    await saveLoggedDay(day, CHECKED_ON);
 
     expect(await loadLoggedDay(DATE)).toEqual(day);
   });
@@ -178,6 +188,7 @@ describe("loadLoggedDay", () => {
   it("resolves entry names without a per-entry lookup", async () => {
     await saveLoggedDay(
       aDay({ symptoms: ["Cramps", "Nausea", "Aura"], moods: ["Calm", "Sad"] }),
+      CHECKED_ON,
     );
 
     const loaded = await loadLoggedDay(DATE);
@@ -187,11 +198,14 @@ describe("loadLoggedDay", () => {
   });
 
   it("does not leak another day's entries", async () => {
-    await saveLoggedDay(aDay({ symptoms: ["Cramps"] }));
-    await saveLoggedDay({
-      ...emptyLoggedDay("2026-04-02"),
-      symptoms: ["Nausea"],
-    });
+    await saveLoggedDay(aDay({ symptoms: ["Cramps"] }), CHECKED_ON);
+    await saveLoggedDay(
+      {
+        ...emptyLoggedDay("2026-04-02"),
+        symptoms: ["Nausea"],
+      },
+      CHECKED_ON,
+    );
 
     expect((await loadLoggedDay(DATE)).symptoms).toEqual(["Cramps"]);
   });
@@ -264,7 +278,7 @@ describe("the saver's timing rules", () => {
   };
 
   it("collapses a burst of edits into one write", async () => {
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     const first = saver.schedule(aDay({ flow: 1 }));
@@ -280,7 +294,7 @@ describe("the saver's timing rules", () => {
   });
 
   it("does not write when nothing changed", async () => {
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     const day = aDay({ flow: 2 });
     saver.reset(day);
 
@@ -293,7 +307,7 @@ describe("the saver's timing rules", () => {
   it("refuses to save a day other than the one currently open", async () => {
     // The user switched days mid-debounce. Writing the old snapshot now would
     // write it against whichever day is open.
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay("2026-04-02"));
 
     const outcome = await saver.schedule(aDay({ flow: 3 }));
@@ -303,7 +317,7 @@ describe("the saver's timing rules", () => {
   });
 
   it("moves its baseline forward after a successful save", async () => {
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     const saved = saver.schedule(aDay({ flow: 3 }));
@@ -314,7 +328,7 @@ describe("the saver's timing rules", () => {
   });
 
   it("cancels a pending write", async () => {
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     const pending = saver.schedule(aDay({ flow: 3 }));
@@ -329,7 +343,7 @@ describe("the saver's timing rules", () => {
     // The report: select a flow, tap another day inside the 100ms debounce,
     // and the flow was silently discarded (#162). The user's edit was to the
     // old day, and writing the old snapshot to the old date is correct.
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     const pending = saver.schedule(aDay({ flow: 3 }));
@@ -344,7 +358,7 @@ describe("the saver's timing rules", () => {
     // DayView flushes in the load effect's cleanup, so the flush starts before
     // loadLoggedDay resolves and calls reset for the new day. The flushed
     // write must still land on the day it was made against.
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     const pending = saver.schedule(aDay({ flow: 3 }));
@@ -361,7 +375,7 @@ describe("the saver's timing rules", () => {
     // The flush settles after the new day's reset, so the baseline has to be
     // the new day's real contents, not the snapshot the flush just wrote.
     const newDay = aDay({ date: OTHER_DATE, flow: 1 });
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     saver.schedule(aDay({ flow: 3 }));
@@ -384,7 +398,7 @@ describe("the saver's timing rules", () => {
     // Select Heavy, change your mind back to None inside the debounce. The
     // second schedule sees nothing changed against the baseline, and the
     // first write must not still be armed behind it (#214).
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     const none = emptyLoggedDay(DATE);
     saver.reset(none);
 
@@ -407,7 +421,7 @@ describe("the saver's timing rules", () => {
     // The asymmetry. `unchanged` means there is nothing left to write, so it
     // disarms. `wrong-day` means the edit belongs to another day, and
     // disarming there is #162.
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     const pending = saver.schedule(aDay({ flow: 3 }));
@@ -420,7 +434,7 @@ describe("the saver's timing rules", () => {
   });
 
   it("has nothing to flush when no write is pending", async () => {
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     expect((await saver.flush()).status).toBe("unchanged");
@@ -428,7 +442,7 @@ describe("the saver's timing rules", () => {
   });
 
   it("reports a failure rather than throwing at the caller", async () => {
-    const saver = createLoggedDaySaver();
+    const saver = createLoggedDaySaver({ now: () => CHECKED_ON });
     saver.reset(emptyLoggedDay(DATE));
 
     const outcome = saver.schedule(aDay({ date: DATE, flow: NaN }));

--- a/db/__tests__/predictionSnapshots.test.ts
+++ b/db/__tests__/predictionSnapshots.test.ts
@@ -32,6 +32,38 @@ beforeEach(() => {
   resetTestDatabase();
 });
 
+describe("checkPredictionAccuracy", () => {
+  it("records when the outcome became known, from its caller", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+
+    await checkPredictionAccuracy("2026-03-20", true, new Date(2026, 2, 20));
+
+    expect(storedSnapshots()[0].checked_date).toBe("2026-03-20");
+  });
+
+  it("does not read the clock", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+
+    // A date the machine's clock cannot be on.
+    await checkPredictionAccuracy("2026-03-20", false, new Date(1999, 0, 5));
+
+    expect(storedSnapshots()[0].checked_date).toBe("1999-01-05");
+  });
+
+  it("dates the check locally", async () => {
+    await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
+
+    // Half past eleven at night is tomorrow in UTC west of it.
+    await checkPredictionAccuracy(
+      "2026-03-20",
+      true,
+      new Date(2026, 2, 20, 23, 30),
+    );
+
+    expect(storedSnapshots()[0].checked_date).toBe("2026-03-20");
+  });
+});
+
 describe("savePredictions", () => {
   it("stores one row per predicted date", async () => {
     await savePredictions(
@@ -116,7 +148,7 @@ describe("savePredictions", () => {
 
   it("never retracts a prediction whose outcome has already been measured", async () => {
     await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
-    await checkPredictionAccuracy("2026-03-20", true);
+    await checkPredictionAccuracy("2026-03-20", true, MARCH_1);
 
     await savePredictions([{ date: "2026-03-25", confidence: 60 }], MARCH_1);
 
@@ -131,7 +163,7 @@ describe("savePredictions", () => {
 
   it("leaves a measured outcome alone when confidence is updated", async () => {
     await savePredictions([{ date: "2026-03-20", confidence: 80 }], MARCH_1);
-    await checkPredictionAccuracy("2026-03-20", true);
+    await checkPredictionAccuracy("2026-03-20", true, MARCH_1);
 
     await savePredictions([{ date: "2026-03-20", confidence: 40 }], MARCH_1);
 
@@ -151,8 +183,8 @@ describe("savePredictions", () => {
       await savePredictions(predictions, MARCH_1);
     }
 
-    await checkPredictionAccuracy("2026-03-20", true);
-    await checkPredictionAccuracy("2026-03-21", false);
+    await checkPredictionAccuracy("2026-03-20", true, MARCH_1);
+    await checkPredictionAccuracy("2026-03-21", false, MARCH_1);
 
     expect(await getPredictionAccuracy()).toEqual({
       totalChecked: 2,

--- a/db/__tests__/refreshPredictions.test.ts
+++ b/db/__tests__/refreshPredictions.test.ts
@@ -33,10 +33,10 @@ const stored = () =>
 /** Two clean cycles, enough for a prediction. */
 async function logTwoCycles() {
   for (const date of ["2026-01-01", "2026-01-02", "2026-01-03", "2026-01-04"]) {
-    await insertDay(date, 3);
+    await insertDay(date, 3, REFERENCE_DAY);
   }
   for (const date of ["2026-01-29", "2026-01-30", "2026-01-31", "2026-02-01"]) {
-    await insertDay(date, 3);
+    await insertDay(date, 3, REFERENCE_DAY);
   }
 }
 
@@ -52,7 +52,7 @@ describe("refreshPredictions", () => {
   });
 
   it("predicts nothing from a single incomplete cycle", async () => {
-    await insertDay("2026-03-01", 2);
+    await insertDay("2026-03-01", 2, new Date(2026, 0, 1));
 
     expect(await refreshPredictions(REFERENCE_DAY)).toEqual([]);
   });

--- a/db/__tests__/testSeam.test.ts
+++ b/db/__tests__/testSeam.test.ts
@@ -56,7 +56,7 @@ describe("the test seam", () => {
   });
 
   it("runs a real db/operations write and read", async () => {
-    await insertDay("2026-03-01", 3);
+    await insertDay("2026-03-01", 3, new Date(2026, 0, 1));
 
     const day = await getDay("2026-03-01");
 

--- a/db/loggedDay.ts
+++ b/db/loggedDay.ts
@@ -186,11 +186,18 @@ async function catalogueIdsByName(
  *
  * Reconcile, not insert: names no longer selected have their entries removed,
  * and per-entry detail is updated in place.
+ *
+ * `checkedOn` is today, which is not `day.date` — a user can log a day in the
+ * past. It reaches the prediction accuracy check that every flow write fires.
  */
-export async function saveLoggedDay(day: LoggedDay): Promise<void> {
+export async function saveLoggedDay(
+  day: LoggedDay,
+  checkedOn: Date,
+): Promise<void> {
   await insertDay(
     day.date,
     day.flow,
+    checkedOn,
     day.notes,
     day.isCycleStart,
     day.isCycleEnd,
@@ -389,9 +396,18 @@ export const DEFAULT_SAVE_DELAY_MS = 100;
  * same pending write immediately, under the same four rules, which is what
  * closing a day needs.
  */
-export function createLoggedDaySaver(
-  options: { delayMs?: number } = {},
-): LoggedDaySaver {
+export function createLoggedDaySaver(options: {
+  /**
+   * Reads the clock at write time, for the prediction accuracy check.
+   *
+   * Required and injected rather than defaulted, so the clock is read at the
+   * app's edge and a test can pin it. A saver outlives any single write, so
+   * it needs a function rather than a value.
+   */
+  now: () => Date;
+  delayMs?: number;
+}): LoggedDaySaver {
+  const { now } = options;
   const delayMs = options.delayMs ?? DEFAULT_SAVE_DELAY_MS;
 
   let baseline: LoggedDay | null = null;
@@ -436,7 +452,7 @@ export function createLoggedDaySaver(
 
     inFlight = true;
     try {
-      await saveLoggedDay(day);
+      await saveLoggedDay(day, now());
       if (baseline?.date === day.date) baseline = day;
       return settle({ status: "saved", day });
     } catch (error) {

--- a/db/operations/days.ts
+++ b/db/operations/days.ts
@@ -20,6 +20,7 @@ export const getAllDays = async () => {
 export const updateDay = async (
   date: string,
   flowIntensity: number,
+  checkedOn: Date,
   notes?: string | null,
   is_cycle_start?: boolean,
   is_cycle_end?: boolean,
@@ -38,14 +39,18 @@ export const updateDay = async (
 
   // Check prediction accuracy when flow is logged
   try {
-    await checkPredictionAccuracy(date, flowIntensity > 0);
+    await checkPredictionAccuracy(date, flowIntensity > 0, checkedOn);
   } catch (error) {
     console.error("Error checking prediction accuracy:", error);
     // Don't fail the whole operation if accuracy checking fails
   }
 };
 
-export const updateDayFlow = async (date: string, flowIntensity: number) => {
+export const updateDayFlow = async (
+  date: string,
+  flowIntensity: number,
+  checkedOn: Date,
+) => {
   await db
     .update(days)
     .set({ flow_intensity: flowIntensity })
@@ -53,7 +58,7 @@ export const updateDayFlow = async (date: string, flowIntensity: number) => {
 
   // Check prediction accuracy when flow is logged
   try {
-    await checkPredictionAccuracy(date, flowIntensity > 0);
+    await checkPredictionAccuracy(date, flowIntensity > 0, checkedOn);
   } catch (error) {
     console.error("Error checking prediction accuracy:", error);
     // Don't fail the whole operation if accuracy checking fails
@@ -97,6 +102,7 @@ export const updateDayIntercourse = async (
 export const insertDay = async (
   date: string,
   flowIntensity: number,
+  checkedOn: Date,
   notes?: string,
   is_cycle_start?: boolean,
   is_cycle_end?: boolean,
@@ -107,6 +113,7 @@ export const insertDay = async (
     await updateDay(
       date,
       flowIntensity,
+      checkedOn,
       notes ?? null,
       is_cycle_start,
       is_cycle_end,

--- a/db/operations/predictionSnapshots.ts
+++ b/db/operations/predictionSnapshots.ts
@@ -82,11 +82,15 @@ export const savePredictions = async (
 };
 
 /**
- * Check predictions against actual data and update accuracy
+ * Check predictions against actual data and update accuracy.
+ *
+ * `checkedOn` is the day the outcome became known, and is a parameter rather
+ * than a clock read. It was the last hidden input in this path.
  */
 export const checkPredictionAccuracy = async (
   date: string,
   hadFlow: boolean,
+  checkedOn: Date,
 ) => {
   // Find all unchecked predictions for this date
   const predictions = await db
@@ -105,7 +109,7 @@ export const checkPredictionAccuracy = async (
       .update(predictionSnapshots)
       .set({
         actual_had_flow: hadFlow,
-        checked_date: formatAsISODate(new Date()),
+        checked_date: formatAsISODate(checkedOn),
       })
       .where(
         and(

--- a/db/quickBirthControl.ts
+++ b/db/quickBirthControl.ts
@@ -51,7 +51,7 @@ export async function quickLogBirthControlForToday(name: string) {
   // make sure the day exists
   let day = await getDay(date);
   if (!day) {
-    await insertDay(date, 0, undefined, false, false);
+    await insertDay(date, 0, new Date(), undefined, false, false);
     day = await getDay(date);
   }
   if (!day?.id) throw new Error("Could not ensure today's day row");


### PR DESCRIPTION
Closes #218. The last clock read in the prediction path.

## What changed

`checkPredictionAccuracy` formatted `checked_date` from `new Date()`. The day now threads down from the app's edge:

`DayView` builds the saver with a `now()` function → the saver calls it at write time → `saveLoggedDay` passes it to `insertDay` → `insertDay` passes it to the accuracy check.

```
✓ records when the outcome became known, from its caller
✓ does not read the clock          ← asserts a 1999 date the machine cannot be on
✓ dates the check locally
```

`checkedOn` is deliberately **not** `day.date`. A user can log a day in the past; the outcome became known today.

## Two judgement calls worth your eye

**1. The saver takes an injected `now: () => Date`, required, not defaulted.** A `createLoggedDaySaver` outlives any single write, so it cannot take a date — it needs to ask. Making it required puts the clock read at the app edge (`DayView`) rather than inside a module, which is the intent of the rule; a defaulted `now` would be the hidden input again wearing a parameter's clothes. This is the only place in the codebase where an injected clock is right. A function that runs once should take the date.

**2. `insertDay` and `updateDay` now take `checkedOn` as a third positional parameter**, ahead of their optional ones. Those signatures are up to seven positional arguments and are overdue for an options object — but converting them is a change to every caller and belongs in its own PR, not smuggled into this one.

## Something I found that changes how you might value this

**`checked_date` is written and read by nothing.** Its only consumer is `getRecentPredictionHistory`, which **has no callers anywhere in the app**. `deleteOldPredictions` has none either.

So the direct payoff here is small: this makes a never-read column testable. The indirect payoff is what I'd actually defend it on — it removes the last hidden input from a path where three separate date defects have already been found, and it means the next person adding prediction history starts from a function that can be tested.

Had I known that before starting, I would have asked whether to **delete `getRecentPredictionHistory` and `deleteOldPredictions`** instead. That is still worth doing and I have not done it here. Say the word.

## Verification

```
$ npx eslint . --max-warnings=0     → 0
$ npm run typecheck                 → 0
$ TZ=UTC npm test -- --ci           → Tests: 243 passed, 243 total
```

`TZ=America/Los_Angeles` shows the same **2 pre-existing failures** as #224 — `db/__tests__/predictionSnapshots.test.ts` constants anchored to UTC, failing on `main`, fixed in #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)