### PR TITLE
lint: turn import/namespace back on (#219)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,13 @@ module.exports = defineConfig([
   {
     rules: {
       "prettier/prettier": "error",
-      "import/namespace": "off",
+      // On deliberately. This is the rule that catches a property read off a
+      // namespace import that the module does not export, which is exactly
+      // how the SDK 54 upgrade broke CSV, JSON and PDF export in a shipped
+      // release: expo-file-system moved cacheDirectory and EncodingType to
+      // its /legacy entry point and nothing complained. It was switched off
+      // globally at the time; the repo has no findings under it now.
+      "import/namespace": "error",
       "react/no-unescaped-entities": "off",
     },
   },


### PR DESCRIPTION
Closes #219.

The issue asked for an experiment, not an implementation: turn the rule on, count the findings, and let the number decide. It did.

## The number is zero

```
$ npx eslint .        # with "import/namespace": "off" removed
EXIT: 0
```

No findings anywhere in the repo. So the "many findings, mostly noise against React Native's module shapes" branch of the issue does not apply, and there is nothing to weigh against turning it on.

## I checked it actually fires

A rule reporting nothing and a rule not running look identical from the outside. A probe file reading an unexported property off a namespace import:

```
rule ON:   2:33  error  'thisDoesNotExist' not found in imported namespace 'FileSystem'  import/namespace
rule OFF:  (nothing)
```

That is precisely the shape of #192, where `expo-file-system@19` moved `cacheDirectory`, `documentDirectory` and `EncodingType` to `/legacy`, the app kept reading them off the default export, and CSV, JSON and PDF export were broken in a shipped release. The four call sites even carried `//"import/namespace": "off"` comments that were never real ESLint directives — the quotes make them plain text.

## Why typecheck does not already cover this

`tsc --noEmit` (added in #194) catches the **constant** half: `cacheDirectory` is simply absent from the new export.

It does not catch the **function** half. `expo-file-system` still exports `writeAsStringAsync` from its default entry as a deprecation shim whose own JSDoc says it throws at runtime. That typechecks perfectly. `import/namespace` would not have caught that one either — but it would have caught the constants, months earlier, without anyone running a build.

## The comment matters more than the line

I left a comment on the rule saying why it is on. The issue's real complaint was not that the rule was off — off may well have been defensible in 2026 — but that nothing recorded why, so the next person has to re-derive it. Now it says.

## Verification

```
$ npx eslint . --max-warnings=0     → 0
$ npm run typecheck                 → 0
$ npm test -- --ci                  → Tests: 240 passed, 240 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)