### PR TITLE
refactor: load a Logged Day in one query, via drizzle relations

### DIFF
--- a/__tests__/helpers/testDatabase.ts
+++ b/__tests__/helpers/testDatabase.ts
@@ -61,6 +61,14 @@ function applyMigrations(connection: BetterSqlite3.Database) {
 let connection: BetterSqlite3.Database | undefined;
 let database: BetterSQLite3Database<typeof schema> | undefined;
 
+/**
+ * Collects the SQL drizzle issues, while `recordQueries` is running.
+ *
+ * `undefined` the rest of the time, so the logger costs nothing and no test
+ * can accidentally read another test's statements.
+ */
+let recording: string[] | undefined;
+
 function open() {
   if (!connection || !database) {
     connection = new BetterSqlite3(":memory:");
@@ -69,7 +77,10 @@ function open() {
     // device swallows into orphaned rows fail loudly here.
     connection.pragma("foreign_keys = ON");
     applyMigrations(connection);
-    database = drizzle(connection, { schema });
+    database = drizzle(connection, {
+      schema,
+      logger: { logQuery: (query) => recording?.push(query) },
+    });
   }
   return { connection, database };
 }
@@ -131,5 +142,27 @@ export function withForeignKeysOff(write: () => void) {
     write();
   } finally {
     db.pragma("foreign_keys = ON");
+  }
+}
+
+/**
+ * Runs `work` and returns every SQL statement drizzle issued for it.
+ *
+ * For assertions about query *count*, which is otherwise unpinnable: a
+ * refactor can quietly reintroduce a per-entry lookup and every behavioural
+ * test still passes. Counting is the only thing that notices.
+ *
+ * Only sees statements that go through drizzle. Raw `connection.prepare` calls
+ * in this helper do not appear, which is what you want.
+ */
+export async function recordQueries<T>(
+  work: () => Promise<T>,
+): Promise<{ result: T; queries: string[] }> {
+  recording = [];
+  try {
+    const result = await work();
+    return { result, queries: [...recording] };
+  } finally {
+    recording = undefined;
   }
 }

--- a/db/__tests__/loggedDay.test.ts
+++ b/db/__tests__/loggedDay.test.ts
@@ -1,3 +1,4 @@
+import { eq } from "drizzle-orm";
 import {
   birthControlIn,
   createLoggedDaySaver,
@@ -18,7 +19,9 @@ import {
 } from "@/db/schema";
 import {
   getTestDatabase,
+  recordQueries,
   resetTestDatabase,
+  withForeignKeysOff,
 } from "@/__tests__/helpers/testDatabase";
 
 jest.mock("@/db/operations/setup", () =>
@@ -208,6 +211,47 @@ describe("loadLoggedDay", () => {
     );
 
     expect((await loadLoggedDay(DATE)).symptoms).toEqual(["Cramps"]);
+  });
+
+  it("issues one query", async () => {
+    await saveLoggedDay(
+      aDay({
+        symptoms: ["Cramps"],
+        moods: ["Calm"],
+        medications: [{ name: "Pill", timeTaken: "08:00" }],
+      }),
+      CHECKED_ON,
+    );
+
+    const { queries } = await recordQueries(() => loadLoggedDay(DATE));
+
+    // The only assertion in this file about how the work is done rather than
+    // what comes back. #202 got this from seven-plus down to four and said so;
+    // nothing else here would notice it going back up.
+    expect(queries).toHaveLength(1);
+  });
+
+  it("skips an entry whose catalogue item is gone", async () => {
+    // Device state, not a contrived one. The app ships no PRAGMA, so foreign
+    // keys are off in production and an entry can outlive the Symptom it
+    // points at — that is what drizzle/0004 was written to clean up. This
+    // reproduces it rather than asserting the constraint the device lacks.
+    await saveLoggedDay(
+      aDay({ symptoms: ["Cramps"], moods: ["Calm"] }),
+      CHECKED_ON,
+    );
+
+    withForeignKeysOff(() => {
+      getTestDatabase()
+        .delete(symptoms)
+        .where(eq(symptoms.name, "Cramps"))
+        .run();
+    });
+
+    const loaded = await loadLoggedDay(DATE);
+
+    expect(loaded.symptoms).toEqual([]);
+    expect(loaded.moods).toEqual(["Calm"]);
   });
 });
 

--- a/db/loggedDay.ts
+++ b/db/loggedDay.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray } from "drizzle-orm";
 import { getDrizzleDatabase } from "@/db/operations/setup";
 import {
+  days,
   medicationEntries,
   medications,
   moodEntries,
@@ -96,39 +97,50 @@ export function loggedDayChanged(a: LoggedDay, b: LoggedDay): boolean {
 }
 
 /**
- * Loads the whole Logged Day.
+ * The catalogue row an entry names, or null if it is no longer there.
  *
- * Entry names are resolved by joining in the database. The path this replaces
- * issued a query per entry after already fetching the same Day row six times.
+ * drizzle's relational query returns the `one(...)` side as null when the row
+ * is missing, and the row really can be missing: the app ships no
+ * `PRAGMA foreign_keys`, so on device the constraint is not enforced and an
+ * entry outlives a deleted Symptom, Mood or Medication. `drizzle/0004` exists
+ * to clean those up, which is the proof they occur.
+ *
+ * Skipping them is what the four `innerJoin`s this replaces did implicitly. A
+ * relational `with` hands them back instead, so the skip has to be written
+ * down. Reading `.name` off one of these without checking is a crash on
+ * opening a day, and it is not a crash `tsc` can see.
+ */
+function nameOf(item: { name: string } | null): string | null {
+  return item?.name ?? null;
+}
+
+function loggedNames<Entry>(
+  entries: Entry[],
+  catalogueItem: (entry: Entry) => { name: string } | null,
+): string[] {
+  return entries.flatMap((entry) => {
+    const name = nameOf(catalogueItem(entry));
+    return name === null ? [] : [name];
+  });
+}
+
+/**
+ * Loads the whole Logged Day, in one query.
+ *
+ * Entry names are resolved in the database through the relations declared in
+ * `db/schema.ts`. The path before #202 issued a query per entry after already
+ * fetching the same Day row six times; #202 got that to four; this is one.
  */
 export async function loadLoggedDay(date: string): Promise<LoggedDay> {
-  const day = await getDay(date);
+  const day = await db.query.days.findFirst({
+    where: eq(days.date, date),
+    with: {
+      symptomEntries: { with: { symptom: true } },
+      moodEntries: { with: { mood: true } },
+      medicationEntries: { with: { medication: true } },
+    },
+  });
   if (!day) return emptyLoggedDay(date);
-
-  const [symptomRows, moodRows, medicationRows] = await Promise.all([
-    db
-      .select({ name: symptoms.name })
-      .from(symptomEntries)
-      .innerJoin(symptoms, eq(symptomEntries.symptom_id, symptoms.id))
-      .where(eq(symptomEntries.day_id, day.id)),
-    db
-      .select({ name: moods.name })
-      .from(moodEntries)
-      .innerJoin(moods, eq(moodEntries.mood_id, moods.id))
-      .where(eq(moodEntries.day_id, day.id)),
-    db
-      .select({
-        name: medications.name,
-        timeTaken: medicationEntries.time_taken,
-        notes: medicationEntries.notes,
-      })
-      .from(medicationEntries)
-      .innerJoin(
-        medications,
-        eq(medicationEntries.medication_id, medications.id),
-      )
-      .where(eq(medicationEntries.day_id, day.id)),
-  ]);
 
   return {
     date,
@@ -137,13 +149,19 @@ export async function loadLoggedDay(date: string): Promise<LoggedDay> {
     isCycleStart: day.is_cycle_start ?? false,
     isCycleEnd: day.is_cycle_end ?? false,
     intercourse: day.intercourse ?? false,
-    symptoms: symptomRows.map((row) => row.name),
-    moods: moodRows.map((row) => row.name),
-    medications: medicationRows.map((row) => ({
-      name: row.name,
-      ...(row.timeTaken ? { timeTaken: row.timeTaken } : {}),
-      ...(row.notes ? { notes: row.notes } : {}),
-    })),
+    symptoms: loggedNames(day.symptomEntries, (entry) => entry.symptom),
+    moods: loggedNames(day.moodEntries, (entry) => entry.mood),
+    medications: day.medicationEntries.flatMap((entry) => {
+      const name = nameOf(entry.medication);
+      if (name === null) return [];
+      return [
+        {
+          name,
+          ...(entry.time_taken ? { timeTaken: entry.time_taken } : {}),
+          ...(entry.notes ? { notes: entry.notes } : {}),
+        },
+      ];
+    }),
   };
 }
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,3 +1,4 @@
+import { relations } from "drizzle-orm";
 import {
   sqliteTable,
   text,
@@ -119,6 +120,67 @@ export const pregnancyAppointments = sqliteTable("pregnancy_appointments", {
   type: text(), // "OB Visit", "Ultrasound", "Lab Work", "Other"
   notes: text(),
 });
+
+/**
+ * The foreign keys above say a column points somewhere. These say what the
+ * shape of the data is, which is what `db.query.…({ with })` needs in order to
+ * load a Day and its entries in one statement instead of four.
+ *
+ * Declared here rather than beside each query because both drizzle handles —
+ * `db/operations/setup.ts` on device and `__tests__/helpers/testDatabase.ts`
+ * under jest — build themselves from `import * as schema`. Exporting them from
+ * this module is what makes the two agree without either knowing about the
+ * other.
+ *
+ * Note what these do NOT do: the app ships no `PRAGMA foreign_keys`, so on
+ * device the constraints are off and an entry can outlive the catalogue row it
+ * names. A relation is a description, not an enforcement. Readers have to cope
+ * with the `one(...)` side being absent.
+ */
+export const daysRelations = relations(days, ({ many }) => ({
+  moodEntries: many(moodEntries),
+  symptomEntries: many(symptomEntries),
+  medicationEntries: many(medicationEntries),
+}));
+
+export const moodEntriesRelations = relations(moodEntries, ({ one }) => ({
+  day: one(days, { fields: [moodEntries.day_id], references: [days.id] }),
+  mood: one(moods, { fields: [moodEntries.mood_id], references: [moods.id] }),
+}));
+
+export const symptomEntriesRelations = relations(symptomEntries, ({ one }) => ({
+  day: one(days, { fields: [symptomEntries.day_id], references: [days.id] }),
+  symptom: one(symptoms, {
+    fields: [symptomEntries.symptom_id],
+    references: [symptoms.id],
+  }),
+}));
+
+export const medicationEntriesRelations = relations(
+  medicationEntries,
+  ({ one }) => ({
+    day: one(days, {
+      fields: [medicationEntries.day_id],
+      references: [days.id],
+    }),
+    medication: one(medications, {
+      fields: [medicationEntries.medication_id],
+      references: [medications.id],
+    }),
+  }),
+);
+
+export const moodsRelations = relations(moods, ({ many }) => ({
+  entries: many(moodEntries),
+}));
+
+export const symptomsRelations = relations(symptoms, ({ many }) => ({
+  entries: many(symptomEntries),
+}));
+
+export const medicationsRelations = relations(medications, ({ many }) => ({
+  entries: many(medicationEntries),
+}));
 
 export type Settings = typeof settings.$inferSelect;
 export type Day = typeof days.$inferSelect;

--- a/docs/adr/0003-relations-describe-shape-they-do-not-enforce-it.md
+++ b/docs/adr/0003-relations-describe-shape-they-do-not-enforce-it.md
@@ -1,0 +1,50 @@
+# ADR 0003: Relations describe shape; the device does not enforce them
+
+- **Status**: Accepted
+- **Date**: 2026-08-19
+- **Context commit**: c72cbe1
+
+## Context
+
+#220 asked for `loadLoggedDay` to load a Day and its entries in one query instead of four. That needs drizzle `relations()` declared in `db/schema.ts`, because without them `db.query.days.findFirst({ with: … })` does not exist.
+
+Declaring them is mechanical. What is not mechanical is what changes about reading the result.
+
+The four queries being replaced were `innerJoin`s. An `innerJoin` against the catalogue table drops any entry whose catalogue row is missing, silently and for free. A relational `with` does the opposite: the entry comes back with its `one(...)` side set to `null`.
+
+Those rows exist. ADR 0002 records why: the app ships no `PRAGMA foreign_keys` anywhere, so foreign keys are **off on device**, and `setupEntryTypes` stranded `symptom_entries`, `mood_entries` and `medication_entries` rows pointing at deleted catalogue ids. `drizzle/0004_orphaned_entries_cleanup.sql` cleans up the ones that already happened; nothing prevents a future path from making more.
+
+The naive rewrite was written, and it crashed:
+
+```
+TypeError: Cannot read properties of null (reading 'name')
+  > symptoms: day.symptomEntries.map((entry) => entry.symptom.name),
+```
+
+That is a crash on opening a day, on ordinary device data, in a shipped release.
+
+## Decision
+
+**`relations()` are declared in `db/schema.ts` and are understood as a description of shape, not as a constraint.** Every reader of a `one(...)` side treats it as possibly absent, regardless of what the foreign key column says or what the types say.
+
+`loadLoggedDay` does this through `nameOf` and `loggedNames`, which skip an entry whose catalogue row is gone — restoring, explicitly, what `innerJoin` was doing implicitly.
+
+**Foreign keys stay off on device**, per ADR 0002. This decision does not reopen that.
+
+## Rationale
+
+The trap is that nothing warns you. The FK columns are `.notNull()`, so the shape reads as guaranteed, and `npm run typecheck` passes on the crashing version. The test suite does not catch it either, and deliberately so: `__tests__/helpers/testDatabase.ts` runs with `PRAGMA foreign_keys = ON`, which is stricter than the device on purpose. Constraints the device does not have cannot produce, in a test, the rows the device does have.
+
+`withForeignKeysOff` exists for exactly this and no other reason: reproducing device state a test cannot otherwise reach. `db/__tests__/loggedDay.test.ts` uses it to delete a Symptom out from under a live entry and assert the day still loads. That test passed against the old `innerJoin` code and failed against the first relational rewrite, which is the whole reason it is worth having.
+
+Turning the constraints on instead would make this decision unnecessary, and is a much larger change: it would have to succeed against every existing install, including ones already holding violating rows, at the moment the database opens.
+
+## Consequences
+
+- A relational query is one statement, but it is a statement built out of `json_group_array` and `json_array` — SQLite's JSON1 functions. `expo-sqlite` vendors SQLite 3.50.3 with JSON built in and nothing sets `SQLITE_OMIT_JSON`, so this is available. It is a dependency to keep in mind on an SDK upgrade (#232).
+- Query count is now asserted, not asserted-about. `recordQueries` in the test helper collects the SQL drizzle issues, and `loadLoggedDay` has a test pinning it at one. Nothing else in the file would notice an N+1 creeping back.
+- Relations are exported from `db/schema.ts` rather than declared next to a query, so both drizzle handles — `db/operations/setup.ts` on device and the test seam under jest — pick them up from their existing `import * as schema`. Neither had to change.
+
+## When to revisit
+
+If `PRAGMA foreign_keys = ON` is ever shipped, the null-handling here becomes dead defensiveness and should go. That is a change to ADR 0002 first.


### PR DESCRIPTION
Closes #220.

`loadLoggedDay` issued four queries. It now issues **one** — measured, not asserted. `recordQueries` in the test seam collects the SQL drizzle emits, and a test pins the count. Here is that test failing before the change:

```
● loadLoggedDay › issues one query
  Expected length: 1
  Received length: 4
  Received array: [
    "select … from \"days\" where \"days\".\"date\" = ? limit ?",
    "select \"symptoms\".\"name\" from \"symptom_entries\" inner join \"symptoms\" …",
    "select \"moods\".\"name\" from \"mood_entries\" inner join \"moods\" …",
    "select \"medications\".\"name\", … from \"medication_entries\" inner join \"medications\" …"
  ]
```

`relations()` are declared in `db/schema.ts` rather than beside the query, so **both** drizzle handles pick them up from the `import * as schema` they already have — `db/operations/setup.ts` on device and `__tests__/helpers/testDatabase.ts` under jest. Neither module needed to change, which is what stops the two drifting apart.

## The part that would have shipped a crash

The four queries were `innerJoin`s. An `innerJoin` drops an entry whose catalogue row is missing, silently and for free. A relational `with` hands the entry back with its catalogue side set to `null` instead.

**Those rows exist on device.** The app ships no `PRAGMA foreign_keys`, so the constraints are off and an entry outlives a deleted Symptom — that is exactly what `drizzle/0004_orphaned_entries_cleanup.sql` was written to clean up. The first version of this rewrite did the obvious thing:

```
TypeError: Cannot read properties of null (reading 'name')
  > 123 |     symptoms: day.symptomEntries.map((entry) => entry.symptom.name),
```

A crash on opening a day, on ordinary device data.

**Nothing would have warned about it.** The foreign key columns are `.notNull()`, so `npm run typecheck` passes on the crashing version. And the test suite runs with `PRAGMA foreign_keys = ON` — deliberately stricter than the device — which means it cannot, on its own, produce the rows the device has.

`withForeignKeysOff` exists for precisely this and nothing else. The new test deletes a Symptom out from under a live entry and asserts the day still loads:

- it **passed** against the old `innerJoin` code
- it **failed** against the naive relational rewrite
- it passes now

That sequence is the reason the test is worth having; a test written after the fix would have proved nothing.

`nameOf` and `loggedNames` restore explicitly what `innerJoin` was doing implicitly.

## What the one query looks like

drizzle builds it as correlated subqueries wrapped in `json_group_array` / `json_array`, so each relation comes back as nested JSON and there is no cross product to unpick in JavaScript.

That is a dependency on SQLite's **JSON1** functions. Checked rather than assumed: `expo-sqlite` vendors SQLite **3.50.3**, `json_group_array` is in the vendored amalgamation, and nothing in its build config sets `SQLITE_OMIT_JSON`. Flagged in #232 as something to re-check on an SDK upgrade.

## Scope

This is structure, not speed — as the issue itself said. Four local queries against an on-device SQLite database were never what felt slow. The value is that the schema now states the shape of the data, and **ADR 0003** records the rule that comes with it: a `one(...)` side is a description, not a guarantee, and every reader treats it as possibly absent.

`hooks/useLiveFilteredData.ts` still hand-rolls its join. Different query, different shape, and it is the subject of #228 — left alone here.

## Verification

```
npm run typecheck   exit 0
npm run lint        exit 0
npm test            263 passed, 20 suites
```

Green in UTC, Europe/Brussels, America/Los_Angeles and Pacific/Auckland.

Not verified on a device. The JSON1 check above is the closest available substitute.