### PR TITLE
refactor: type the 25 remaining explicit anys, turn noExplicitAny on

### DIFF
--- a/app/(onboarding)/tour.tsx
+++ b/app/(onboarding)/tour.tsx
@@ -40,7 +40,7 @@ export default function TourStart() {
       ];
 
       // Go to the first route, then start the tour overlay.
-      router.replace(steps[0].route as any);
+      router.replace(steps[0].route);
       start(steps);
     })();
   }, [start]);

--- a/app/(onboarding)/welcome.tsx
+++ b/app/(onboarding)/welcome.tsx
@@ -6,7 +6,7 @@ export default function NameScreen() {
   const theme = useTheme();
 
   function onContinue() {
-    router.push({ pathname: "/(onboarding)/tour" as any });
+    router.push({ pathname: "/(onboarding)/tour" });
   }
 
   return (

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -9,15 +9,15 @@ export default function Index() {
     (async () => {
       const seen = await getHasSeenWalkthrough();
       if (!seen) {
-        router.replace("/(onboarding)/welcome" as any);
+        router.replace("/(onboarding)/welcome");
         return;
       }
       const modeSetting = await getSetting(SettingsKeys.trackingMode);
       const mode = modeSetting?.value ?? TRACKING_MODES.CYCLE;
       if (mode === TRACKING_MODES.PREGNANCY) {
-        router.replace("/(pregnancy-tabs)" as any);
+        router.replace("/(pregnancy-tabs)");
       } else {
-        router.replace("/(tabs)" as any);
+        router.replace("/(tabs)");
       }
     })();
   }, []);

--- a/assets/src/tour/SpotlightOverlay.tsx
+++ b/assets/src/tour/SpotlightOverlay.tsx
@@ -1,11 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
+import type React from "react";
 import { Dimensions, Modal, Pressable, Text, View } from "react-native";
 import { useTour } from "./TourContext";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type Rect = { x: number; y: number; width: number; height: number };
 
-function measure(ref: any): Promise<Rect | null> {
+function measure(
+  ref: React.RefObject<View | null> | undefined,
+): Promise<Rect | null> {
   return new Promise((resolve) => {
     if (!ref?.current?.measureInWindow) return resolve(null);
     ref.current.measureInWindow(

--- a/assets/src/tour/TourAnchor.tsx
+++ b/assets/src/tour/TourAnchor.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useEffect, useRef } from "react";
-import { View } from "react-native";
+import { type StyleProp, View, type ViewStyle } from "react-native";
 import { useTour } from "./TourContext";
 
 export function TourAnchor({
@@ -10,7 +10,7 @@ export function TourAnchor({
 }: {
   id: string;
   children: React.ReactNode;
-  style?: any;
+  style?: StyleProp<ViewStyle>;
 }) {
   const ref = useRef<View>(null);
   const { registerAnchor } = useTour();

--- a/assets/src/tour/TourContext.tsx
+++ b/assets/src/tour/TourContext.tsx
@@ -8,10 +8,11 @@ import {
   useState,
 } from "react";
 import { router } from "expo-router";
+import type { View } from "react-native";
 import type { TourStep } from "./types";
 import { setHasSeenWalkthrough } from "../onboarding/onboarding-storage";
 
-type AnchorRef = React.RefObject<any>;
+type AnchorRef = React.RefObject<View | null>;
 
 type TourState = {
   isActive: boolean;
@@ -69,7 +70,7 @@ export function TourProvider({ children }: { children: React.ReactNode }) {
 
       const step = steps[index];
       // Navigate first so the anchor actually exists in the UI tree.
-      router.replace(step.route as any);
+      router.replace(step.route);
 
       // Give the UI a moment to render before the overlay measures anchors.
       await new Promise((r) => setTimeout(r, 350));

--- a/assets/src/tour/types.ts
+++ b/assets/src/tour/types.ts
@@ -1,6 +1,14 @@
+import type { Href } from "expo-router";
+
 export type TourStep = {
   id: string;
   title: string;
   text: string;
-  route: string;
+  /**
+   * Checked against the routes expo-router generates, not a free string.
+   * `.expo/types/router.d.ts` is gitignored, so CI typechecks with a
+   * permissive `Href` and cannot catch a typo here — a local `expo start`
+   * regenerates it and can.
+   */
+  route: Href;
 };

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -37,11 +37,12 @@
     "rules": {
       "preset": "recommended",
       "suspicious": {
-        // Off for enforcement parity: ESLint never had
-        // @typescript-eslint/no-explicit-any on either, so leaving it off
-        // changes nothing about what this repo enforces. 25 sites across 16
-        // files; burning them down is real typing work with its own issue.
-        "noExplicitAny": "off"
+        // On since #228 burned down all 25 sites. Two of them were hiding
+        // real defects rather than being merely lazy: nine `as any` route
+        // casts were silencing a stale generated `.expo/types/router.d.ts`
+        // and disabling route checking to do it, and `DayData` was declaring
+        // four nullable columns non-null.
+        "noExplicitAny": "error"
       },
       "correctness": {
         // reportUnnecessaryDependencies is off deliberately. `databaseChange`

--- a/components/FlowChart.tsx
+++ b/components/FlowChart.tsx
@@ -10,6 +10,7 @@ import Svg, {
 } from "react-native-svg";
 import React, { useEffect, useRef, useMemo } from "react";
 import { FlowColors, type FlowType } from "@/constants/Colors";
+import type { DayData } from "@/constants/Interfaces";
 import { useTheme } from "react-native-paper";
 import { useData, useFlowData } from "@/stores/calendar-storage";
 import { useFocusEffect } from "@react-navigation/native";
@@ -120,7 +121,7 @@ export default function FlowChart() {
     }, []),
   );
 
-  const filterFlowDataForCurrentMonth = (flowData: any[]) => {
+  const filterFlowDataForCurrentMonth = (flowData: DayData[]) => {
     if (flowData.length === 0) {
       setFlowDataForCurrentMonth([]);
     } else {

--- a/components/__tests__/FlowChart.gradient.test.ts
+++ b/components/__tests__/FlowChart.gradient.test.ts
@@ -5,7 +5,17 @@ import { FLOW_TAIL_COLOR, getFlowTypeString } from "@/constants/Flow";
  * Test helper: Extract gradient logic from FlowChart component
  * This mirrors the gradient generation logic in FlowChart.tsx
  */
-function generateGradientStops(flowDataForCurrentMonth: any[]): {
+/**
+ * Only the two fields the gradient reads, and `flow_intensity` as nullable.
+ *
+ * `DayData` declares it `number`, which is not true: the `days.flow_intensity`
+ * column is nullable, and the cases below deliberately pass `undefined` and
+ * `null` because the production code handles them. `DayData[]` here would
+ * reject the tests that matter most.
+ */
+type FlowDay = { date: string; flow_intensity?: number | null };
+
+function generateGradientStops(flowDataForCurrentMonth: FlowDay[]): {
   stops: { offset: string; color: string }[];
   flowStatesInOrder: FlowType[];
 } {

--- a/components/dayView/BirthControlAccordion.tsx
+++ b/components/dayView/BirthControlAccordion.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { View, Modal, Platform } from "react-native";
 import { List, Text, Button, TextInput, useTheme } from "react-native-paper";
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker, {
+  type DateTimePickerEvent,
+} from "@react-native-community/datetimepicker";
 import SingleChipSelection from "./SingleChipSelection";
 import { loggingAccordionTitleStyles } from "@/components/dayView/loggingGridLayout";
 import type { LoggedMedication } from "@/db/loggedDay";
@@ -51,7 +53,10 @@ export default function BirthControlAccordion({
   const setBirthControlNotes = (notes: string) =>
     setBirthControl(birthControl ? { ...birthControl, notes } : null);
 
-  const handleTimeChange = (event: any, selectedTime?: Date) => {
+  const handleTimeChange = (
+    event: DateTimePickerEvent,
+    selectedTime?: Date,
+  ) => {
     if (Platform.OS === "android") {
       if (event.type === "set" && selectedTime) {
         setTempSelectedTime(selectedTime);

--- a/components/settings/ExportData.tsx
+++ b/components/settings/ExportData.tsx
@@ -90,14 +90,12 @@ function formatJsonDataToCsv(exportData: ExportDataInterface) {
       row.push(entry.moods.includes(mood) ? "x" : "");
     }
     for (const medication of headers.medications) {
-      const medValue = entry.medications.find(
-        (m: any) => m.name === medication,
-      );
+      const medValue = entry.medications.find((m) => m.name === medication);
       row.push(medValue ? "x" : "");
     }
     for (const birthControl of headers.birth_control) {
       const bcValue = entry.birth_control.find(
-        (bc: any) => bc.name === birthControl,
+        (bc) => bc.name === birthControl,
       );
 
       if (bcValue) {

--- a/components/settings/NotificationSettings.tsx
+++ b/components/settings/NotificationSettings.tsx
@@ -17,7 +17,9 @@ import {
 } from "@/constants/Notifications";
 import { NotificationService } from "@/services/notificationService";
 import { usePredictedCycle } from "@/stores/calendar-storage";
-import DateTimePicker from "@react-native-community/datetimepicker";
+import DateTimePicker, {
+  type DateTimePickerEvent,
+} from "@react-native-community/datetimepicker";
 
 export default function NotificationSettings() {
   const theme = useTheme();
@@ -103,7 +105,10 @@ export default function NotificationSettings() {
     await saveSettings(newSettings);
   };
 
-  const handleTimeChange = async (event: any, selectedDate?: Date) => {
+  const handleTimeChange = async (
+    event: DateTimePickerEvent,
+    selectedDate?: Date,
+  ) => {
     setShowTimePicker(false);
 
     if (event.type === "set" && selectedDate) {

--- a/components/settings/TrackingModeSettings.tsx
+++ b/components/settings/TrackingModeSettings.tsx
@@ -44,9 +44,9 @@ export default function TrackingModeSettings() {
             setLocalMode(targetMode);
             setTrackingMode(targetMode);
             if (targetMode === TRACKING_MODES.PREGNANCY) {
-              router.replace("/(pregnancy-tabs)" as any);
+              router.replace("/(pregnancy-tabs)");
             } else {
-              router.replace("/(tabs)" as any);
+              router.replace("/(tabs)");
             }
           },
         },

--- a/components/settings/WalkthroughReplay.tsx
+++ b/components/settings/WalkthroughReplay.tsx
@@ -19,7 +19,7 @@ export default function WalkthroughReplay() {
           <View style={{ paddingHorizontal: 16, paddingBottom: 12 }}>
             <Button
               mode="contained"
-              onPress={() => router.push("/(onboarding)/tour" as any)}
+              onPress={() => router.push("/(onboarding)/tour")}
             >
               See App Walkthrough
             </Button>

--- a/constants/Interfaces.ts
+++ b/constants/Interfaces.ts
@@ -10,11 +10,11 @@
 export interface DayData {
   id: number;
   date: string;
-  flow_intensity: number;
-  is_cycle_start?: boolean;
-  is_cycle_end?: boolean;
+  flow_intensity: number | null;
+  is_cycle_start?: boolean | null;
+  is_cycle_end?: boolean | null;
   intercourse?: boolean | null;
-  notes?: string;
+  notes?: string | null;
   moods?: string[];
   symptoms?: string[];
   medications?: string[];

--- a/db/__tests__/dayRows.test.ts
+++ b/db/__tests__/dayRows.test.ts
@@ -1,0 +1,96 @@
+import { daysFromJoinedRows, type JoinedDayRow } from "@/db/dayRows";
+import type { Day } from "@/db/schema";
+
+const day = (overrides: Partial<Day> = {}): Day => ({
+  id: 1,
+  date: "2026-04-01",
+  flow_intensity: 2,
+  is_cycle_start: false,
+  is_cycle_end: false,
+  intercourse: false,
+  notes: null,
+  ...overrides,
+});
+
+const named = (id: number, name: string) => ({ day_id: 1, id, name });
+
+const row = (overrides: Partial<JoinedDayRow> = {}): JoinedDayRow => ({
+  days: day(),
+  moodQuery: null,
+  symptomQuery: null,
+  medicationQuery: null,
+  ...overrides,
+});
+
+describe("daysFromJoinedRows", () => {
+  it("returns nothing for no rows", () => {
+    expect(daysFromJoinedRows([])).toEqual([]);
+  });
+
+  it("keeps the day's own fields", () => {
+    const [result] = daysFromJoinedRows([
+      row({
+        days: day({ flow_intensity: 3, notes: "heavy", intercourse: true }),
+      }),
+    ]);
+
+    expect(result).toMatchObject({
+      id: 1,
+      date: "2026-04-01",
+      flow_intensity: 3,
+      notes: "heavy",
+      intercourse: true,
+    });
+  });
+
+  it("gives a day with no entries three empty arrays", () => {
+    expect(daysFromJoinedRows([row()])).toEqual([
+      { ...day(), moods: [], symptoms: [], medications: [] },
+    ]);
+  });
+
+  it("collapses the cross product three left joins produce", () => {
+    // Two moods and three symptoms on one day come back from SQL as six rows,
+    // every mood paired with every symptom. The whole reason this function
+    // exists is that six rows are one day with two moods and three symptoms,
+    // not one day with six of each.
+    const moods = [named(1, "Calm"), named(2, "Sad")];
+    const symptoms = [named(1, "Cramps"), named(2, "Nausea"), named(3, "Aura")];
+
+    const rows = moods.flatMap((moodQuery) =>
+      symptoms.map((symptomQuery) => row({ moodQuery, symptomQuery })),
+    );
+    expect(rows).toHaveLength(6);
+
+    const [result] = daysFromJoinedRows(rows);
+
+    expect(result.moods).toEqual(["Calm", "Sad"]);
+    expect(result.symptoms).toEqual(["Cramps", "Nausea", "Aura"]);
+  });
+
+  it("collapses two catalogue rows sharing a name", () => {
+    // `medications.name` has no unique constraint, unlike `moods.name` and
+    // `symptoms.name`. Two distinct Medication rows can be called the same
+    // thing, and this dedupes by name, so the day shows one. Pinning the
+    // behaviour rather than endorsing it.
+    const [result] = daysFromJoinedRows([
+      row({ medicationQuery: named(1, "Pill") }),
+      row({ medicationQuery: named(2, "Pill") }),
+    ]);
+
+    expect(result.medications).toEqual(["Pill"]);
+  });
+
+  it("keeps separate days separate", () => {
+    const second = day({ id: 2, date: "2026-04-02" });
+
+    const result = daysFromJoinedRows([
+      row({ moodQuery: named(1, "Calm") }),
+      row({ days: second, moodQuery: { day_id: 2, id: 2, name: "Sad" } }),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].moods).toEqual(["Calm"]);
+    expect(result[1].moods).toEqual(["Sad"]);
+  });
+});

--- a/db/database.ts
+++ b/db/database.ts
@@ -112,7 +112,7 @@ export async function getAllDataAsJson() {
         entry.medication_name &&
         entry.medication_type !== "birth control" &&
         !exportData.dailyData[entry.date].medications.some(
-          (med: any) => med.name === entry.medication_name,
+          (med) => med.name === entry.medication_name,
         )
       ) {
         exportData.dailyData[entry.date].medications.push({
@@ -130,7 +130,7 @@ export async function getAllDataAsJson() {
         entry.medication_name &&
         entry.medication_type === "birth control" &&
         !exportData.dailyData[entry.date].birth_control.some(
-          (bc: any) => bc.name === entry.medication_name,
+          (bc) => bc.name === entry.medication_name,
         )
       ) {
         exportData.dailyData[entry.date].birth_control.push({

--- a/db/dayRows.ts
+++ b/db/dayRows.ts
@@ -1,0 +1,59 @@
+import type { DayData } from "@/constants/Interfaces";
+import type { Day } from "@/db/schema";
+
+/**
+ * A catalogue row as the visibility-filtered subqueries return it, or null
+ * when this row of the outer join has none of that kind.
+ */
+type JoinedCatalogueItem = { day_id: number; id: number; name: string } | null;
+
+/**
+ * One row of the three-way left join in `useLiveFilteredData`.
+ *
+ * Written out rather than derived from the query, because the query lives in
+ * the hook and this module is the thing being tested. The call site is what
+ * checks it: drizzle's row type has to be assignable to this. Note what that
+ * does and does not prove — it proves every field declared here exists on the
+ * real row with a compatible type; it does not prove this declares everything
+ * the row has. A narrower type passes silently.
+ */
+export type JoinedDayRow = {
+  days: Day;
+  moodQuery: JoinedCatalogueItem;
+  symptomQuery: JoinedCatalogueItem;
+  medicationQuery: JoinedCatalogueItem;
+};
+
+/**
+ * Folds the rows of that join into one entry per Day.
+ *
+ * Three left joins against the same Day return the cross product: a day with
+ * two Moods and three Symptoms arrives as six rows, each Mood paired with each
+ * Symptom. Collapsing that back is the entire job. Names are deduped, in first
+ * appearance order.
+ */
+export function daysFromJoinedRows(rows: JoinedDayRow[]): DayData[] {
+  const byId = new Map<number, DayData>();
+
+  for (const { days, moodQuery, symptomQuery, medicationQuery } of rows) {
+    const existing = byId.get(days.id);
+    const day = existing ?? {
+      ...days,
+      moods: [],
+      symptoms: [],
+      medications: [],
+    };
+    if (!existing) byId.set(days.id, day);
+
+    push(day.moods, moodQuery);
+    push(day.symptoms, symptomQuery);
+    push(day.medications, medicationQuery);
+  }
+
+  return [...byId.values()];
+}
+
+function push(names: string[] | undefined, item: JoinedCatalogueItem) {
+  if (!names || !item) return;
+  if (!names.includes(item.name)) names.push(item.name);
+}

--- a/hooks/useLiveFilteredData.ts
+++ b/hooks/useLiveFilteredData.ts
@@ -5,43 +5,7 @@ import { eq } from "drizzle-orm";
 import type { DayData } from "@/constants/Interfaces";
 import { useEffect, useState } from "react";
 import { useDatabaseChangeNotifier } from "@/stores/calendar-storage";
-
-function formatSQLData(data: any) {
-  const formattedData = data.reduce((acc: any, row: any) => {
-    const { days, moodQuery, symptomQuery, medicationQuery } = row;
-
-    let dayEntry = acc.find((entry: any) => entry.id === days.id);
-
-    if (!dayEntry) {
-      dayEntry = {
-        ...days,
-        moods: [],
-        symptoms: [],
-        medications: [],
-      };
-      acc.push(dayEntry);
-    }
-
-    if (moodQuery && !dayEntry.moods.includes(moodQuery.name)) {
-      dayEntry.moods.push(moodQuery.name);
-    }
-
-    if (symptomQuery && !dayEntry.symptoms.includes(symptomQuery.name)) {
-      dayEntry.symptoms.push(symptomQuery.name);
-    }
-
-    if (
-      medicationQuery &&
-      !dayEntry.medications.includes(medicationQuery.name)
-    ) {
-      dayEntry.medications.push(medicationQuery.name);
-    }
-
-    return acc;
-  }, []);
-
-  return formattedData;
-}
+import { daysFromJoinedRows } from "@/db/dayRows";
 
 export const useLiveFilteredData = (filters: string[]) => {
   const db = getDrizzleDatabase();
@@ -104,8 +68,7 @@ export const useLiveFilteredData = (filters: string[]) => {
   useEffect(() => {
     setLoading(true);
     if (data && filters.length > 0) {
-      const formattedData = formatSQLData(data);
-      setFilteredData(formattedData as DayData[]);
+      setFilteredData(daysFromJoinedRows(data));
     } else {
       setFilteredData([]);
     }

--- a/hooks/useMarkedDates.ts
+++ b/hooks/useMarkedDates.ts
@@ -199,8 +199,14 @@ async function markedDatesBuilder(filters: string[], data: DayData[]) {
     if (filters.some((filter) => filter === "Flow")) {
       const { isStartingDay, isEndingDay } = getStartingAndEndingDay(
         day.date,
-        data[index - 1]?.flow_intensity > 0 ? data[index - 1]?.date : undefined,
-        data[index + 1]?.flow_intensity > 0 ? data[index + 1]?.date : undefined,
+        // `?? 0` because flow_intensity is a nullable column. The type used
+        // to say otherwise; the code below already defended against it.
+        (data[index - 1]?.flow_intensity ?? 0) > 0
+          ? data[index - 1]?.date
+          : undefined,
+        (data[index + 1]?.flow_intensity ?? 0) > 0
+          ? data[index + 1]?.date
+          : undefined,
       );
       if (!markedDates[day.date])
         markedDates[day.date] = { selected: false, periods: [] };

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -19,7 +19,12 @@ Notifications.setNotificationHandler({
 export interface ScheduleNotificationConfig {
   title: string;
   body: string;
-  data?: Record<string, any>;
+  /**
+   * Whatever the caller wants handed back when the notification is tapped.
+   * `unknown`, not `any`: nothing here reads it, and a reader that starts to
+   * should be made to say what it expects.
+   */
+  data?: Record<string, unknown>;
   trigger: Date | null; // null for immediate notification
   sound?: boolean;
 }


### PR DESCRIPTION
Closes #228. Two commits: the 21 that were signature changes, then the four that were not.

The issue suggested one PR per file. I did two commits in one PR instead, because splitting further would have meant either merging a broken `DayData` or leaving `noExplicitAny` off across three PRs. Each commit is independently green.

## Nine of the 25 were one bug, not nine judgment calls

`router.replace("/(pregnancy-tabs)" as any)` and its eight siblings. `experiments.typedRoutes` is **already on**. The problem is that `.expo/` is gitignored, so the generated `.expo/types/router.d.ts` is whatever each machine last produced:

- **In CI the file does not exist at all.** `Href` falls back to permissive, `tsc` passes with or without the casts, and a route typo is caught neither way.
- **The local copy was stale.** It predated pregnancy mode — no `(pregnancy-tabs)` routes in it — and still listed `/(tabs)/__tests__/index.test`, a file deleted back in #178.

So the casts silenced a regeneration problem, and the price was turning route checking off permanently. Regenerating the file makes `(pregnancy-tabs)` a known route and every cast deletes. Verified both ways:

```
fresh router.d.ts, casts removed      tsc exit 0
no  router.d.ts, casts removed        tsc exit 0   ← what CI sees
stale router.d.ts, casts removed      tsc exit 2   ← the state that caused them
```

`TourStep.route` becomes `Href` instead of `string`, which is what lets `router.replace(step.route)` lose its cast rather than relocate it.

## The last four needed tests before they needed types

`hooks/useLiveFilteredData.ts` — the module the phase 0 test seam left out of scope, and the one with no coverage. `formatSQLData` moves into `db/dayRows.ts` as `daysFromJoinedRows`, which makes it a pure function over row shapes: no database, no react, trivially testable. Six tests it never had, written before the types.

The one that matters: **three left joins return the cross product.** A day with two Moods and three Symptoms arrives from SQL as six rows, every Mood paired with every Symptom. Collapsing that back is the entire reason the function exists, and nothing checked it.

Also pinned: two catalogue rows sharing a name collapse to one entry. `medications.name` has **no unique constraint**, unlike `moods.name` and `symptoms.name`, so this is reachable. Characterized, not endorsed.

`JoinedDayRow` is hand-written rather than derived, since the query stays in the hook. The call site checks it — and I confirmed that check isn't vacuous by deliberately mistyping there:

```
Type '{ days: { id: number; date: string; flow_intensity: number | null;
        is_cycle_start: boolean | null; ... };
        moodQuery: {...} | null; symptomQuery: {...} | null;
        medicationQuery: {...} | null }[]' is not assignable to type 'number'.
```

`data` is genuinely typed, so assignability means something. To be precise about **what** it means: every field declared in `JoinedDayRow` exists on the real row with a compatible type. It does not prove the declaration is complete — a narrower type would pass silently.

## DayData was lying about four columns

Typing that spread honestly is what surfaced it:

| field | column | was declared |
| --- | --- | --- |
| `flow_intensity` | nullable | `number` |
| `is_cycle_start` | nullable | `boolean` |
| `is_cycle_end` | nullable | `boolean` |
| `notes` | nullable | `string` |

Same class as ADR 0003: a type asserting non-null over a nullable column. **Already violated at runtime** — the old `formatSQLData` has been spreading rows with `notes: null` into `DayData` all along, behind an `any`.

Pure type change, no behaviour change. The whole ripple is two lines in `useMarkedDates.ts`, where the code was already defending against the null the type denied:

```ts
- data[index - 1]?.flow_intensity > 0
+ (data[index - 1]?.flow_intensity ?? 0) > 0
```

It also showed up in `FlowChart.gradient.test.ts`, which deliberately passes `flow_intensity` as `undefined` and `null` because the production code handles both — typing that helper as `DayData[]` would have rejected exactly the cases worth testing.

## The rest

- `event: any` → `DateTimePickerEvent` (`NotificationSettings`, `BirthControlAccordion`)
- `(m: any)` / `(bc: any)` / `(med: any)` in `ExportData` and `db/database.ts` — `.find`/`.some` callbacks over already-typed arrays; the annotations narrowed nothing, so deleting them lets inference work
- `style?: any` → `StyleProp<ViewStyle>`, `RefObject<any>` → `RefObject<View | null>`
- `Record<string, any>` → `Record<string, unknown>` on the notification payload

`noExplicitAny` goes to `error` in the **last** commit, per the issue, so CI stayed green throughout.

## Verification

```
npm run typecheck   exit 0
npm run lint        exit 0
npm test            269 passed, 21 suites   (was 263 / 20)
```

Green in UTC, Europe/Brussels, America/Los_Angeles and Pacific/Auckland.