### PR TITLE
refactor: one keyed record per settings screen, not four arrays

### DIFF
--- a/components/settings/CustomEntries.tsx
+++ b/components/settings/CustomEntries.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { Fragment, useState, useEffect } from "react";
 import {
   getAllSymptoms,
   getAllMoods,
@@ -32,9 +32,14 @@ import { moodOptions } from "@/constants/Moods";
 import { birthControlOptions } from "@/constants/BirthControlTypes";
 import {
   addCatalogueItem,
+  CATALOGUE_KIND_TITLES,
+  CATALOGUE_KINDS,
+  type CatalogueKind,
+  type CatalogueLists,
+  catalogueNameTaken,
+  emptyCatalogueLists,
   invalidateCatalogue,
   removeCatalogueItem,
-  type CatalogueKind,
 } from "@/db/catalogue";
 
 function InfoDialog({
@@ -120,9 +125,9 @@ function AccordionContents({
   onDeleteEntry,
 }: {
   items: string[];
-  itemType: string;
-  onAddEntry: (entryType: string, entryName: string) => void;
-  onDeleteEntry: (entryType: string, entryName: string) => void;
+  itemType: CatalogueKind;
+  onAddEntry: (entryType: CatalogueKind, entryName: string) => void;
+  onDeleteEntry: (entryType: CatalogueKind, entryName: string) => void;
 }) {
   const theme = useTheme();
   const { width, height } = Dimensions.get("window");
@@ -130,7 +135,7 @@ function AccordionContents({
   const [input, setInput] = useState("");
   const [deleteDialogVisible, setDeleteDialogVisible] = useState(false);
   const [entryName, setEntryName] = useState("");
-  const [entryType, setEntryType] = useState("");
+  const [entryType, setEntryType] = useState<CatalogueKind>(itemType);
 
   return (
     <ScrollView style={styles.scrollview}>
@@ -212,10 +217,9 @@ function CustomEntriesModal({
   const setDbChange = useDatabaseChangeNotifier().setDatabaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
   const [expanded, setExpanded] = useState<string>(initialExpandedCatalogue);
-  const [symptoms, setSymptoms] = useState<string[]>([]);
-  const [moods, setMoods] = useState<string[]>([]);
-  const [medications, setMedications] = useState<string[]>([]);
-  const [birthControl, setBirthControl] = useState<string[]>([]);
+  const [lists, setLists] = useState<CatalogueLists<string>>(
+    emptyCatalogueLists<string>,
+  );
   const [infoDialogVisible, setInfoDialogVisible] = useState(false);
   const [snackbarVisible, setSnackbarVisible] = useState(false);
   const [snackbarText, setSnackbarText] = useState("");
@@ -223,69 +227,62 @@ function CustomEntriesModal({
   // Get all custom entries from the database. Custom entries are ones that
   // aren't included in the default list of symptoms, moods, and medications.
   useEffect(() => {
-    const fetchSymptoms = async () => {
-      const symptoms = await getAllSymptoms();
-      const customSymptoms = symptoms.filter(
-        (symptom) => !symptomOptions.includes(symptom.name),
-      );
-      setSymptoms(customSymptoms.map((symptom) => symptom.name));
-    };
-    const fetchMoods = async () => {
-      const moods = await getAllMoods();
-      const customMoods = moods.filter(
-        (mood) => !moodOptions.includes(mood.name),
-      );
-      setMoods(customMoods.map((mood) => mood.name));
-    };
-    const fetchMedications = async () => {
-      const medications = await getAllMedications();
-      const customMedications = medications.filter(
+    const fetchCustomEntries = async () => {
+      const [allSymptoms, allMoods, allMedications] = await Promise.all([
+        getAllSymptoms(),
+        getAllMoods(),
+        getAllMedications(),
+      ]);
+
+      // A medication is custom if it is in neither shipped list, whichever
+      // Section it belongs to; `type` only decides which of the two it lands
+      // in afterwards.
+      const customMedications = allMedications.filter(
         (medication) =>
           !medicationOptions.includes(medication.name) &&
-          !birthControlOptions.includes(medication.name) &&
-          medication.type !== "birth control",
+          !birthControlOptions.includes(medication.name),
       );
-      const customBirthControl = medications.filter(
-        (medication) =>
-          !medicationOptions.includes(medication.name) &&
-          !birthControlOptions.includes(medication.name) &&
-          medication.type === "birth control",
-      );
-      setMedications(customMedications.map((medication) => medication.name));
-      setBirthControl(customBirthControl.map((bc) => bc.name));
+
+      setLists({
+        symptom: allSymptoms
+          .filter((symptom) => !symptomOptions.includes(symptom.name))
+          .map((symptom) => symptom.name),
+        mood: allMoods
+          .filter((mood) => !moodOptions.includes(mood.name))
+          .map((mood) => mood.name),
+        medication: customMedications
+          .filter((medication) => medication.type !== "birth control")
+          .map((medication) => medication.name),
+        "birth control": customMedications
+          .filter((medication) => medication.type === "birth control")
+          .map((medication) => medication.name),
+      });
     };
 
-    fetchSymptoms();
-    fetchMoods();
-    fetchMedications();
+    fetchCustomEntries();
   }, []);
 
-  /** This screen's own copy of each list. Display state, not the Catalogue. */
-  const listFor = (kind: string) =>
-    ({
-      symptom: { get: () => symptoms, set: setSymptoms },
-      mood: { get: () => moods, set: setMoods },
-      medication: { get: () => medications, set: setMedications },
-      "birth control": { get: () => birthControl, set: setBirthControl },
-    })[kind] ?? { get: () => [] as string[], set: () => {} };
+  /**
+   * This screen's own copy of each list. Display state, not the Catalogue.
+   *
+   * Functional, so two updates in one tick cannot lose each other. The four
+   * separate `useState`s this replaces were updated from a closed-over value.
+   */
+  const updateList = (
+    kind: CatalogueKind,
+    update: (names: string[]) => string[],
+  ) =>
+    setLists((previous) => ({ ...previous, [kind]: update(previous[kind]) }));
 
-  const onAddEntry = (entryType: string, entryName: string) => {
-    // check for duplicate entries, account for spaces, underscore, and capitilazation
-    const squashedEntryName = entryName.replace(/[_\s]/g, "").toLowerCase();
-    const allEntries = [
-      ...symptoms,
-      ...moods,
-      ...medications,
-      ...birthControl,
+  const onAddEntry = (entryType: CatalogueKind, entryName: string) => {
+    const taken = catalogueNameTaken(entryName, [
+      ...CATALOGUE_KINDS.flatMap((kind) => lists[kind]),
       ...symptomOptions,
       ...moodOptions,
       ...medicationOptions,
       ...birthControlOptions,
-    ];
-    const squashedAllEntries = allEntries.map((entry) =>
-      entry.replace(/[_\s]/g, "").toLowerCase(),
-    );
-    if (squashedAllEntries.includes(squashedEntryName)) {
+    ]);
+    if (taken) {
       setSnackbarText(`${entryName} already exists.`);
       setSnackbarVisible(true);
       return;
@@ -293,16 +290,14 @@ function CustomEntriesModal({
 
     // Which table a kind means lives in db/catalogue.ts. What is left here is
     // this screen's own list, which is display state.
-    addCatalogueItem(entryType as CatalogueKind, entryName);
-    listFor(entryType).set([...listFor(entryType).get(), entryName]);
+    addCatalogueItem(entryType, entryName);
+    updateList(entryType, (names) => [...names, entryName]);
   };
 
-  const onDeleteEntry = (entryType: string, entryName: string) => {
-    removeCatalogueItem(entryType as CatalogueKind, entryName);
-    listFor(entryType).set(
-      listFor(entryType)
-        .get()
-        .filter((item) => item !== entryName),
+  const onDeleteEntry = (entryType: CatalogueKind, entryName: string) => {
+    removeCatalogueItem(entryType, entryName);
+    updateList(entryType, (names) =>
+      names.filter((name) => name !== entryName),
     );
 
     // check if entry is in calendar filters and remove if needed
@@ -346,58 +341,23 @@ function CustomEntriesModal({
             expandedId={expanded}
             onAccordionPress={(expandedId) => setExpanded(String(expandedId))}
           >
-            <List.Accordion
-              title="Symptoms"
-              id="symptom"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={symptoms}
-                itemType="symptom"
-                onAddEntry={onAddEntry}
-                onDeleteEntry={onDeleteEntry}
-              />
-            </List.Accordion>
-            <Divider />
-            <List.Accordion
-              title="Moods"
-              id="mood"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={moods}
-                itemType="mood"
-                onAddEntry={onAddEntry}
-                onDeleteEntry={onDeleteEntry}
-              />
-            </List.Accordion>
-            <Divider />
-            <List.Accordion
-              title="Medications"
-              id="medication"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={medications}
-                itemType="medication"
-                onAddEntry={onAddEntry}
-                onDeleteEntry={onDeleteEntry}
-              />
-            </List.Accordion>
-            <Divider />
-            <List.Accordion
-              title="Birth Control"
-              id="birth control"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={birthControl}
-                itemType="birth control"
-                onAddEntry={onAddEntry}
-                onDeleteEntry={onDeleteEntry}
-              />
-            </List.Accordion>
-            <Divider />
+            {CATALOGUE_KINDS.map((kind) => (
+              <Fragment key={kind}>
+                <List.Accordion
+                  title={CATALOGUE_KIND_TITLES[kind]}
+                  id={kind}
+                  titleStyle={styles.listTitle}
+                >
+                  <AccordionContents
+                    items={lists[kind]}
+                    itemType={kind}
+                    onAddEntry={onAddEntry}
+                    onDeleteEntry={onDeleteEntry}
+                  />
+                </List.Accordion>
+                <Divider />
+              </Fragment>
+            ))}
           </List.AccordionGroup>
         </ThemedView>
         <InfoDialog

--- a/components/settings/EntryVisibilitySettings.tsx
+++ b/components/settings/EntryVisibilitySettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { Fragment, useState, useEffect } from "react";
 import {
   getAllSymptoms,
   getAllMoods,
@@ -26,33 +26,23 @@ import {
   useDatabaseChangeNotifier,
 } from "@/stores/calendar-storage";
 import {
+  CATALOGUE_KIND_TITLES,
+  CATALOGUE_KINDS,
+  type CatalogueKind,
+  type CatalogueLists,
+  emptyCatalogueLists,
   invalidateCatalogue,
   setCatalogueItemVisible,
-  type CatalogueKind,
 } from "@/db/catalogue";
 
-interface Symptom {
-  id: number;
-  name: string;
-  visible?: boolean;
-  description?: string;
-}
-
-interface Mood {
-  id: number;
-  name: string;
-  visible?: boolean;
-  description?: string;
-}
-
-interface Medication {
-  id: number;
-  name: string;
-  dose?: string;
-  visible?: boolean;
-  type?: string;
-  description?: string;
-}
+/**
+ * What this screen needs of a catalogue row: enough to list it and toggle it.
+ *
+ * Replaces three near-identical local interfaces that restated
+ * `db/schema.ts`'s Symptom, Mood and Medication and disagreed with them on
+ * nullability, which is why every fetch here used to end in an `as` cast.
+ */
+type VisibilityItem = { id: number; name: string; visible: boolean | null };
 
 function InfoDialog({
   visible,
@@ -96,12 +86,9 @@ function AccordionContents({
   itemType,
   onToggleSwitch,
 }: {
-  items: Symptom[] | Mood[] | Medication[];
-  itemType: string;
-  onToggleSwitch: (
-    entryType: string,
-    entry: Symptom | Mood | Medication,
-  ) => void;
+  items: VisibilityItem[];
+  itemType: CatalogueKind;
+  onToggleSwitch: (entryType: CatalogueKind, entry: VisibilityItem) => void;
 }) {
   const theme = useTheme();
   const { width, height } = Dimensions.get("window");
@@ -121,7 +108,9 @@ function AccordionContents({
             title={item.name}
             right={() => (
               <Switch
-                key={`${item}-${isVisible}`}
+                // `${item}` here stringified the row to "[object Object]",
+                // making every switch in the list share one key.
+                key={`${item.id}-${isVisible}`}
                 value={isVisible}
                 onValueChange={() => onToggleSwitch(itemType, item)}
               />
@@ -140,71 +129,55 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
   const setDbChange = useDatabaseChangeNotifier().setDatabaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
   const [expanded, setExpanded] = useState<string>("1");
-  const [symptoms, setSymptoms] = useState<Symptom[]>([]);
-  const [moods, setMoods] = useState<Mood[]>([]);
-  const [medications, setMedications] = useState<Medication[]>([]);
-  const [birthControl, setBirthControl] = useState<Medication[]>([]);
+  const [lists, setLists] = useState<CatalogueLists<VisibilityItem>>(
+    emptyCatalogueLists<VisibilityItem>,
+  );
   const [infoDialogVisible, setInfoDialogVisible] = useState(false);
 
   useEffect(() => {
-    const fetchSymptoms = async () => {
-      const symptoms = await getAllSymptoms();
-      setSymptoms(symptoms as Symptom[]);
-    };
-    const fetchMoods = async () => {
-      const moods = await getAllMoods();
-      setMoods(moods as Mood[]);
-    };
-    const fetchMedications = async () => {
-      const medications = await getAllMedications();
-      setMedications(
-        medications.filter(
+    const fetchEntries = async () => {
+      const [allSymptoms, allMoods, allMedications] = await Promise.all([
+        getAllSymptoms(),
+        getAllMoods(),
+        getAllMedications(),
+      ]);
+
+      setLists({
+        symptom: allSymptoms,
+        mood: allMoods,
+        medication: allMedications.filter(
           (medication) => medication.type !== "birth control",
-        ) as Medication[],
-      );
-      setBirthControl(
-        medications.filter(
+        ),
+        "birth control": allMedications.filter(
           (medication) => medication.type === "birth control",
-        ) as Medication[],
-      );
+        ),
+      });
     };
 
-    fetchSymptoms();
-    fetchMoods();
-    fetchMedications();
+    fetchEntries();
   }, []);
 
-  /** This screen's own copy of each list. Display state, not the Catalogue. */
-  const listFor = (kind: string) =>
-    ({
-      symptom: { get: () => symptoms, set: setSymptoms },
-      mood: { get: () => moods, set: setMoods },
-      medication: { get: () => medications, set: setMedications },
-      "birth control": { get: () => birthControl, set: setBirthControl },
-    })[kind] ?? {
-      get: () => [] as { id: number; name: string; visible: boolean }[],
-      set: () => {},
-    };
+  /**
+   * This screen's own copy of each list. Display state, not the Catalogue.
+   *
+   * Functional, so two updates in one tick cannot lose each other. The four
+   * separate `useState`s this replaces were updated from a closed-over value.
+   */
+  const updateList = (
+    kind: CatalogueKind,
+    update: (items: VisibilityItem[]) => VisibilityItem[],
+  ) =>
+    setLists((previous) => ({ ...previous, [kind]: update(previous[kind]) }));
 
-  const onToggleSwitch = (
-    entryType: string,
-    entry: Symptom | Mood | Medication,
-  ) => {
+  const onToggleSwitch = (entryType: CatalogueKind, entry: VisibilityItem) => {
     // Which table a kind means lives in db/catalogue.ts. What is left here is
     // this screen's own list, which is display state.
-    setCatalogueItemVisible(
-      entryType as CatalogueKind,
-      entry.name,
-      !entry.visible,
-    );
+    setCatalogueItemVisible(entryType, entry.name, !entry.visible);
 
-    const list = listFor(entryType);
-    list.set(
-      list
-        .get()
-        .map((item) =>
-          item.id === entry.id ? { ...item, visible: !item.visible } : item,
-        ),
+    updateList(entryType, (items) =>
+      items.map((item) =>
+        item.id === entry.id ? { ...item, visible: !item.visible } : item,
+      ),
     );
 
     // check if entry is in calendar filters and remove if needed
@@ -248,54 +221,22 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
             expandedId={expanded}
             onAccordionPress={(expandedId) => setExpanded(String(expandedId))}
           >
-            <List.Accordion
-              title="Symptoms"
-              id="symptom"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={symptoms}
-                itemType="symptom"
-                onToggleSwitch={onToggleSwitch}
-              />
-            </List.Accordion>
-            <Divider />
-            <List.Accordion
-              title="Moods"
-              id="mood"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={moods}
-                itemType="mood"
-                onToggleSwitch={onToggleSwitch}
-              />
-            </List.Accordion>
-            <Divider />
-            <List.Accordion
-              title="Medications"
-              id="medication"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={medications}
-                itemType="medication"
-                onToggleSwitch={onToggleSwitch}
-              />
-            </List.Accordion>
-            <Divider />
-            <List.Accordion
-              title="Birth Control"
-              id="birth control"
-              titleStyle={styles.listTitle}
-            >
-              <AccordionContents
-                items={birthControl}
-                itemType="birth control"
-                onToggleSwitch={onToggleSwitch}
-              />
-            </List.Accordion>
-            <Divider />
+            {CATALOGUE_KINDS.map((kind) => (
+              <Fragment key={kind}>
+                <List.Accordion
+                  title={CATALOGUE_KIND_TITLES[kind]}
+                  id={kind}
+                  titleStyle={styles.listTitle}
+                >
+                  <AccordionContents
+                    items={lists[kind]}
+                    itemType={kind}
+                    onToggleSwitch={onToggleSwitch}
+                  />
+                </List.Accordion>
+                <Divider />
+              </Fragment>
+            ))}
           </List.AccordionGroup>
         </ThemedView>
         <InfoDialog

--- a/db/__tests__/catalogue.test.ts
+++ b/db/__tests__/catalogue.test.ts
@@ -1,6 +1,8 @@
 import {
   addCatalogueItem,
+  CATALOGUE_KIND_TITLES,
   CATALOGUE_KINDS,
+  catalogueNameTaken,
   invalidateCatalogue,
   loadCatalogue,
   onCatalogueInvalidated,
@@ -188,5 +190,61 @@ describe("editing the catalogue", () => {
 
     expect(catalogue.birthControl).not.toContain("Patch");
     expect(catalogue.medications).not.toContain("Patch");
+  });
+});
+
+describe("catalogueNameTaken", () => {
+  const existing = ["Cramps", "Hot flashes", "mini_pill"];
+
+  it("is false for a name nothing else uses", () => {
+    expect(catalogueNameTaken("Nausea", existing)).toBe(false);
+  });
+
+  it("is true for an exact match", () => {
+    expect(catalogueNameTaken("Cramps", existing)).toBe(true);
+  });
+
+  it("ignores case", () => {
+    expect(catalogueNameTaken("cRaMpS", existing)).toBe(true);
+  });
+
+  it("ignores spaces and underscores", () => {
+    // "Hot flashes" and "hot_flashes" are the same thing to a user typing it
+    // in, and the catalogue is one flat list of names, so letting both in
+    // makes two entries that look identical in every accordion.
+    expect(catalogueNameTaken("hot_flashes", existing)).toBe(true);
+    expect(catalogueNameTaken("Mini Pill", existing)).toBe(true);
+  });
+
+  it("compares against every kind, not just the one being added to", () => {
+    // The four kinds are four lists in the UI but one namespace to the user.
+    expect(catalogueNameTaken("cramps", ["Calm", "Cramps"])).toBe(true);
+  });
+
+  it("is false against nothing", () => {
+    expect(catalogueNameTaken("Nausea", [])).toBe(false);
+  });
+});
+
+describe("the four kinds, as settings shows them", () => {
+  it("is an order both settings screens now render from", () => {
+    // CustomEntries and EntryVisibilitySettings used to spell out four
+    // accordions each. They map over this instead, so reordering it for some
+    // unrelated reason silently reorders both screens.
+    expect([...CATALOGUE_KINDS]).toEqual([
+      "symptom",
+      "mood",
+      "medication",
+      "birth control",
+    ]);
+  });
+
+  it("names every kind", () => {
+    expect(CATALOGUE_KINDS.map((kind) => CATALOGUE_KIND_TITLES[kind])).toEqual([
+      "Symptoms",
+      "Moods",
+      "Medications",
+      "Birth Control",
+    ]);
   });
 });

--- a/db/catalogue.ts
+++ b/db/catalogue.ts
@@ -23,6 +23,40 @@ export const CATALOGUE_KINDS = [
 
 export type CatalogueKind = (typeof CATALOGUE_KINDS)[number];
 
+/** What each kind is called in settings, where all four are shown at once. */
+export const CATALOGUE_KIND_TITLES: Record<CatalogueKind, string> = {
+  symptom: "Symptoms",
+  mood: "Moods",
+  medication: "Medications",
+  "birth control": "Birth Control",
+};
+
+/** One list per kind. What a settings screen holds while it is open. */
+export type CatalogueLists<Item> = Record<CatalogueKind, Item[]>;
+
+export const emptyCatalogueLists = <Item>(): CatalogueLists<Item> => ({
+  symptom: [],
+  mood: [],
+  medication: [],
+  "birth control": [],
+});
+
+/**
+ * Whether a name is already in use, the way a user would judge it.
+ *
+ * Spacing, underscores and capitalisation are not differences: "Hot flashes",
+ * "hot_flashes" and "HOTFLASHES" are one thing to whoever typed them, and the
+ * accordions would show them as three indistinguishable rows.
+ *
+ * `existing` is every name across all four kinds, not just the one being added
+ * to. The kinds are four lists on screen and one namespace to the user.
+ */
+export function catalogueNameTaken(name: string, existing: string[]): boolean {
+  const squash = (value: string) => value.replace(/[_\s]/g, "").toLowerCase();
+  const squashed = squash(name);
+  return existing.some((other) => squash(other) === squashed);
+}
+
 /**
  * What the user can choose from while logging. See CONTEXT.md, Catalogue.
  *


### PR DESCRIPTION
Closes #221.

`CustomEntries` and `EntryVisibilitySettings` each held four `useState` arrays and a `listFor(kind)` accessor to pick between them. Both now hold one `Record<CatalogueKind, Item[]>` and index it directly. `listFor` is gone from both.

The four near-identical `List.Accordion` blocks in each screen collapse the same way — a map over `CATALOGUE_KINDS`, display names from a new `CATALOGUE_KIND_TITLES`. Same four ids, same titles, same order, `Divider` after each. `Fragment`, not a wrapper `View`, so the rendered tree is unchanged.

## Three things the restructure exposed

**Duplicate detection was domain logic living in a component.** `onAddEntry` squashed spaces, underscores and case to decide whether a name was already taken, inline. That moves to `db/catalogue.ts` as `catalogueNameTaken` — six tests it never had, written before the implementation. Same move #185 made with the four-way switch: the knowledge belongs next to the Catalogue, not in a screen. It also documents a rule that was previously implicit, that the four kinds are four lists on screen but **one namespace** to the user.

**Three interfaces restating `db/schema.ts`.** `EntryVisibilitySettings` declared its own `Symptom`, `Mood` and `Medication`. All three disagreed with the schema on nullability, which is exactly why every fetch in that file ended in an `as` cast. One `VisibilityItem` says what the screen actually needs and the casts delete.

**A React key that was always the same string.** `key={\`${item}-${isVisible}\`}` stringified the row object to `"[object Object]"`, so every switch in a list shared one key. Now `item.id`.

## Behaviour

None intended.

`updateList` is functional where the four `useState`s were updated from a closed-over value. That is a correctness improvement no current caller can observe — nothing here writes two lists in one tick — but it is correct by construction now rather than by accident.

The fetch effects go from three fire-and-forget async functions to one `Promise.all` and one `setLists`. Same end state, fewer renders.

## Guard

The issue named it: `npm run typecheck` plus a careful read of the JSX, because this repo has no screen-component test harness and standing one up for two components is disproportionate. The JSX diff is 1:1 — four ids, four titles, four dividers, same order.

The order is a **new coupling** worth pinning. Both screens now render from `CATALOGUE_KINDS` instead of spelling the accordions out, so reordering that constant for some unrelated reason would silently reorder both screens. Two tests say so out loud.

## Verification

```
npm run typecheck   exit 0
npm run lint        exit 0
npm test            271 passed, 21 suites
```

Green in UTC, Europe/Brussels, America/Los_Angeles and Pacific/Auckland.

Not verified on a device — these are two settings modals and the guard above is what the issue asked for.