### PR TITLE
fix: call emptyCatalogueLists rather than handing it to useState

### DIFF
--- a/components/settings/CustomEntries.tsx
+++ b/components/settings/CustomEntries.tsx
@@ -217,8 +217,10 @@ function CustomEntriesModal({
   const setDbChange = useDatabaseChangeNotifier().setDatabaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
   const [expanded, setExpanded] = useState<string>(initialExpandedCatalogue);
-  const [lists, setLists] = useState<CatalogueLists<string>>(
-    emptyCatalogueLists<string>,
+  // Called, not passed: useState treats a bare function as a lazy
+  // initializer, which happens to work here and reads like a value.
+  const [lists, setLists] = useState<CatalogueLists<string>>(() =>
+    emptyCatalogueLists<string>(),
   );
   const [infoDialogVisible, setInfoDialogVisible] = useState(false);
   const [snackbarVisible, setSnackbarVisible] = useState(false);

--- a/components/settings/EntryVisibilitySettings.tsx
+++ b/components/settings/EntryVisibilitySettings.tsx
@@ -129,8 +129,10 @@ function CalendarEntriesModal({ onDismiss }: { onDismiss: () => void }) {
   const setDbChange = useDatabaseChangeNotifier().setDatabaseChange;
   const { selectedFilters, setSelectedFilters } = useCalendarFilters();
   const [expanded, setExpanded] = useState<string>("1");
-  const [lists, setLists] = useState<CatalogueLists<VisibilityItem>>(
-    emptyCatalogueLists<VisibilityItem>,
+  // Called, not passed: useState treats a bare function as a lazy
+  // initializer, which happens to work here and reads like a value.
+  const [lists, setLists] = useState<CatalogueLists<VisibilityItem>>(() =>
+    emptyCatalogueLists<VisibilityItem>(),
   );
   const [infoDialogVisible, setInfoDialogVisible] = useState(false);
 

--- a/db/__tests__/catalogue.test.ts
+++ b/db/__tests__/catalogue.test.ts
@@ -3,6 +3,7 @@ import {
   CATALOGUE_KIND_TITLES,
   CATALOGUE_KINDS,
   catalogueNameTaken,
+  emptyCatalogueLists,
   invalidateCatalogue,
   loadCatalogue,
   onCatalogueInvalidated,
@@ -246,5 +247,26 @@ describe("the four kinds, as settings shows them", () => {
       "Medications",
       "Birth Control",
     ]);
+  });
+});
+
+describe("emptyCatalogueLists", () => {
+  it("has an empty list for every kind", () => {
+    expect(emptyCatalogueLists<string>()).toEqual({
+      symptom: [],
+      mood: [],
+      medication: [],
+      "birth control": [],
+    });
+  });
+
+  it("builds a fresh record each time", () => {
+    // Both settings screens hold one of these as component state. Returning a
+    // shared object would let one open modal mutate the other's lists.
+    const first = emptyCatalogueLists<string>();
+    const second = emptyCatalogueLists<string>();
+
+    expect(first).not.toBe(second);
+    expect(first.symptom).not.toBe(second.symptom);
   });
 });


### PR DESCRIPTION
Follow-up to #221, from re-reading it.

Both settings screens had:

```ts
const [lists, setLists] = useState<CatalogueLists<T>>(emptyCatalogueLists<T>);
```

That **is** correct — React treats a bare function argument as a lazy initializer and calls it. But it is correct by accident of the signature, and it reads as though a value is being passed. `() => emptyCatalogueLists<T>()` says what actually happens.

Two tests pin what both screens now depend on and nothing checked:

- every kind starts as an empty list
- each call builds a **fresh** record

The second matters: a shared object would let one open modal mutate the other's lists, and this repo has no screen-component harness that would catch it. Neither `tsc` nor the existing suite covers it, because the function is only ever called through React.

```
npm run typecheck   exit 0
npm run lint        exit 0
npm test            279 passed
```