### PR TITLE
Finish candidates 09 and 10, and fix four defects

### DIFF
--- a/components/settings/ExportData.tsx
+++ b/components/settings/ExportData.tsx
@@ -16,6 +16,7 @@ import {
 } from "react-native-paper";
 import { StyleSheet, Dimensions } from "react-native";
 import type { ExportData as ExportDataInterface } from "@/constants/Interfaces";
+import { toCsv } from "@/services/exportRows";
 import { exportPDF } from "@/components/settings/PdfBuilder";
 
 const exportDescriptions: Record<string, string> = {
@@ -51,76 +52,6 @@ async function exportCsvOrJson(data: string, fileType: string) {
   }
 }
 
-function formatJsonDataToCsv(exportData: ExportDataInterface) {
-  const { headers, dailyData } = exportData;
-  const headerRow: string[] = [...headers.base_header];
-  const csvRows: string[] = [];
-
-  // build header row
-  headers.symptoms.forEach((s: string) => {
-    headerRow.push(`symptom.${s}`);
-  });
-  headers.moods.forEach((m: string) => {
-    headerRow.push(`mood.${m}`);
-  });
-  headers.medications.forEach((m: string) => {
-    headerRow.push(`medication.${m}`);
-  });
-  headers.birth_control.forEach((bc: string) => {
-    headerRow.push(`birth_control.${bc}`);
-    headerRow.push(`birth_control.${bc}.notes`);
-  });
-  csvRows.push(headerRow.join(","));
-
-  // build data rows
-  for (const dayEntry of Object.entries(dailyData)) {
-    // dayEntry[0] is the date, dayEntry[1] is the entry object
-    const entry = dayEntry[1];
-
-    const row: string[] = [
-      entry.date,
-      String(entry.flow_intensity),
-      `"${entry.notes}"`,
-    ];
-
-    for (const symptom of headers.symptoms) {
-      row.push(entry.symptoms.includes(symptom) ? "x" : "");
-    }
-    for (const mood of headers.moods) {
-      row.push(entry.moods.includes(mood) ? "x" : "");
-    }
-    for (const medication of headers.medications) {
-      const medValue = entry.medications.find((m) => m.name === medication);
-      row.push(medValue ? "x" : "");
-    }
-    for (const birthControl of headers.birth_control) {
-      const bcValue = entry.birth_control.find(
-        (bc) => bc.name === birthControl,
-      );
-
-      if (bcValue) {
-        row.push("x");
-
-        let notes = "";
-        if (bcValue.time_taken) {
-          notes += `Time Taken: ${bcValue.time_taken}`;
-        }
-        if (bcValue.notes) {
-          notes += ` Notes: ${bcValue.notes}`;
-        }
-        // wrap the whole note in quotes to preserve potential user commas
-        row.push(`"${notes}"`);
-      } else {
-        row.push("", "");
-      }
-    }
-    csvRows.push(row.join(","));
-  }
-
-  const csvString = csvRows.join("\n");
-  return csvString;
-}
-
 function ExportDataModal({ onDismiss }: { onDismiss: () => void }) {
   const theme = useTheme();
   const { width, height } = Dimensions.get("window");
@@ -132,26 +63,33 @@ function ExportDataModal({ onDismiss }: { onDismiss: () => void }) {
   };
 
   const onExportData = async (format: string) => {
-    const exportData = await getAllDataAsJson();
-    if (!exportData) {
-      throw new Error("Failed to retrieve data for export.");
-    }
-
-    switch (format) {
-      case "csv": {
-        const csvString = formatJsonDataToCsv(exportData);
-        await exportCsvOrJson(csvString, "csv");
-        break;
+    try {
+      const exportData = await getAllDataAsJson();
+      if (!exportData) {
+        throw new Error("Failed to retrieve data for export.");
       }
-      case "pdf":
-        await exportPDF(exportData.dailyData);
-        break;
-      case "json":
-        await exportCsvOrJson(
-          JSON.stringify(exportData.dailyData, null, 2),
-          "json",
-        );
-        break;
+
+      switch (format) {
+        case "csv": {
+          await exportCsvOrJson(toCsv(exportData), "csv");
+          break;
+        }
+        case "pdf":
+          await exportPDF(exportData.dailyData);
+          break;
+        case "json":
+          await exportCsvOrJson(
+            JSON.stringify(exportData.dailyData, null, 2),
+            "json",
+          );
+          break;
+      }
+    } catch (error) {
+      // A PDF export used to fail silently: exportPDF caught everything into a
+      // console.error, so the share sheet simply never appeared and the user
+      // was told nothing.
+      console.error(`Error exporting ${format}:`, error);
+      alert("Something went wrong while exporting your data.");
     }
   };
 

--- a/components/settings/PdfBuilder.ts
+++ b/components/settings/PdfBuilder.ts
@@ -8,6 +8,7 @@ import {
 import * as FileSystem from "expo-file-system/legacy";
 import * as Sharing from "expo-sharing";
 import type { ExportData } from "../../constants/Interfaces";
+import { birthControlDetail, groupEntriesByMonth } from "@/services/exportRows";
 
 const fontSize = 10;
 const verticalPadding = 2;
@@ -18,21 +19,6 @@ const columnWidths = [50, 50, 110, 110, 120, 120];
 const tableWidth = columnWidths.reduce((a, b) => a + b, 0);
 const flowMap = ["", "Spotting", "Light", "Medium", "Heavy"];
 const lightGray = rgb(0.95, 0.95, 0.95);
-
-const MONTH_INDEX: Record<string, number> = {
-  January: 0,
-  February: 1,
-  March: 2,
-  April: 3,
-  May: 4,
-  June: 5,
-  July: 6,
-  August: 7,
-  September: 8,
-  October: 9,
-  November: 10,
-  December: 11,
-};
 
 // wrap text to fit within the specified number of characters
 function wrapText(text: string, maxChars: number): string[] {
@@ -101,7 +87,15 @@ function drawRowText(
   });
 }
 
-async function exportFinishedPdf(pdfDoc: PDFDocument) {
+/**
+ * Write the finished document and hand it to the share sheet.
+ *
+ * Separate from laying the pages out, so that producing the bytes and getting
+ * them off the device are two things rather than one. It rejects rather than
+ * logging: a failed export used to be indistinguishable from a successful one
+ * from the user's side.
+ */
+async function shareFinishedPdf(pdfDoc: PDFDocument) {
   const pdfBase64 = await pdfDoc.saveAsBase64();
   const pdfPath = `${FileSystem.documentDirectory}ephira.pdf`;
   await FileSystem.writeAsStringAsync(pdfPath, pdfBase64, {
@@ -191,38 +185,12 @@ export async function exportPDF(dailyData: ExportData["dailyData"]) {
       y -= 0.5;
     };
 
-    // group entries by month/year so we can sort them
-    const entriesGroupedByMonth: Record<string, ExportData["dailyData"]> = {};
-    for (const entry of Object.values(dailyData)) {
-      const dateObj = new Date(entry.date);
-      const monthKey = dateObj.toLocaleString("default", {
-        month: "long",
-        year: "numeric",
-      });
-
-      if (!entriesGroupedByMonth[monthKey]) {
-        entriesGroupedByMonth[monthKey] = {};
-      }
-
-      entriesGroupedByMonth[monthKey][entry.date] = entry;
-    }
-
-    const sortedMonthKeys = Object.keys(entriesGroupedByMonth).sort((a, b) => {
-      const [monthA, yearA] = a.split(" ");
-      const [monthB, yearB] = b.split(" ");
-
-      const timeA = Date.UTC(Number(yearA), MONTH_INDEX[monthA]);
-      const timeB = Date.UTC(Number(yearB), MONTH_INDEX[monthB]);
-
-      return timeB - timeA;
-    });
-
-    // months will be added to the PDF in reverse order, e.g. May 2025 -> March 2025
-    for (const monthLabel of sortedMonthKeys) {
-      const entries = Object.values(entriesGroupedByMonth[monthLabel]).sort(
-        (a, b) => a.date.localeCompare(b.date),
-      );
-
+    // months are added newest first, e.g. May 2025 -> March 2025. The grouping
+    // and the ordering are in services/exportRows.ts, keyed on the date rather
+    // than on a localised month name.
+    for (const { label: monthLabel, entries } of groupEntriesByMonth(
+      Object.values(dailyData),
+    )) {
       // add month header & column headers
       drawMonthLabel(monthLabel);
       drawColumnHeaders();
@@ -240,10 +208,8 @@ export async function exportPDF(dailyData: ExportData["dailyData"]) {
 
         const bcList = entry.birth_control
           .map((bc) => {
-            let str = "";
-            if (bc.time_taken) str += `Time: ${bc.time_taken}`;
-            if (bc.notes) str += `${str ? ", " : ""}Notes: ${bc.notes}`;
-            return `${bc.name}${str ? ` (${str})` : ""}`;
+            const detail = birthControlDetail(bc);
+            return `${bc.name}${detail ? ` (${detail})` : ""}`;
           })
           .join(", ");
 
@@ -286,8 +252,11 @@ export async function exportPDF(dailyData: ExportData["dailyData"]) {
     }
 
     drawPageNumber();
-    await exportFinishedPdf(pdfDoc);
+    await shareFinishedPdf(pdfDoc);
   } catch (err) {
     console.error("Failed to export PDF:", err);
+    // Rethrow: the caller shows the user something. Swallowing this made a
+    // failed export look exactly like a successful one.
+    throw err;
   }
 }

--- a/hooks/usePregnancyMarkedDates.ts
+++ b/hooks/usePregnancyMarkedDates.ts
@@ -3,92 +3,12 @@ import { useLiveQuery } from "drizzle-orm/expo-sqlite";
 import { getDrizzleDatabase } from "@/db/database";
 import * as schema from "@/db/schema";
 import type { MarkedDates } from "@/constants/Interfaces";
-import { AppointmentColor, SpecialtyFilterColor } from "@/constants/Colors";
-import { usePregnancySelectedDate } from "@/stores/pregnancy-storage";
+import { buildPregnancyMarkedDates } from "@/services/pregnancyMarkedDates";
 
 const db = getDrizzleDatabase();
 
-function buildPregnancyMarkedDates(
-  filters: string[],
-  pregnancyDays: schema.PregnancyDay[],
-  appointments: schema.PregnancyAppointment[],
-): MarkedDates {
-  const markedDates: MarkedDates = {};
-
-  const appointmentsFilter = filters.includes("Appointments");
-  const symptomsFilter = filters.includes("Symptoms");
-  const moodsFilter = filters.includes("Moods");
-  const kicksFilter = filters.includes("Kicks");
-  const notesFilter = filters.includes("Notes");
-
-  // Build appointment markers (dots on dates that have appointments)
-  if (appointmentsFilter) {
-    for (const appt of appointments) {
-      if (!markedDates[appt.date]) {
-        markedDates[appt.date] = { selected: false, periods: [] };
-      }
-      // Only add one appointment period per date even if multiple appointments exist
-      const alreadyHasAppt = markedDates[appt.date].periods.some(
-        (p) => p.color === AppointmentColor,
-      );
-      if (!alreadyHasAppt) {
-        markedDates[appt.date].periods.push({
-          startingDay: true,
-          endingDay: true,
-          color: AppointmentColor,
-        });
-      }
-    }
-  }
-
-  // Build day-level markers from pregnancyDays
-  for (const day of pregnancyDays) {
-    if (!markedDates[day.date]) {
-      markedDates[day.date] = { selected: false, periods: [] };
-    }
-
-    const daySymptoms: string[] = day.symptoms ? JSON.parse(day.symptoms) : [];
-    const dayMoods: string[] = day.moods ? JSON.parse(day.moods) : [];
-
-    if (symptomsFilter && daySymptoms.length > 0) {
-      markedDates[day.date].periods.push({
-        startingDay: true,
-        endingDay: true,
-        color: SpecialtyFilterColor,
-      });
-    }
-
-    if (moodsFilter && dayMoods.length > 0) {
-      markedDates[day.date].periods.push({
-        startingDay: true,
-        endingDay: true,
-        color: SpecialtyFilterColor,
-      });
-    }
-
-    if (kicksFilter && day.kicks != null && day.kicks > 0) {
-      markedDates[day.date].periods.push({
-        startingDay: true,
-        endingDay: true,
-        color: SpecialtyFilterColor,
-      });
-    }
-
-    if (notesFilter && day.notes && day.notes.trim() !== "") {
-      markedDates[day.date].periods.push({
-        startingDay: true,
-        endingDay: true,
-        color: SpecialtyFilterColor,
-      });
-    }
-  }
-
-  return markedDates;
-}
-
 export function usePregnancyMarkedDates(filters: string[]) {
   const [markedDates, setMarkedDates] = useState<MarkedDates>({});
-  const { date } = usePregnancySelectedDate();
 
   const { data: pregnancyDaysData } = useLiveQuery(
     db.select().from(schema.pregnancyDays).orderBy(schema.pregnancyDays.date),
@@ -109,18 +29,9 @@ export function usePregnancyMarkedDates(filters: string[]) {
     setMarkedDates(newMarkedDates);
   }, [pregnancyDaysData, appointmentsData, filters]);
 
-  // keep selected date highlighted
-  useEffect(() => {
-    if (!date) return;
-    setMarkedDates((prev) => {
-      const updated = { ...prev };
-      Object.keys(updated).forEach((d) => {
-        updated[d] = { ...updated[d], selected: false };
-      });
-      updated[date] = { ...(updated[date] ?? { periods: [] }), selected: true };
-      return updated;
-    });
-  }, [date]);
+  // Selection is applied by the calendar screen at render, where the Selected
+  // Date and the theme colours it needs both live. The effect that used to
+  // maintain it here wrote a field its only consumer overwrote unconditionally.
 
   return { markedDates };
 }

--- a/services/__tests__/cycleMarkedDates.test.ts
+++ b/services/__tests__/cycleMarkedDates.test.ts
@@ -320,18 +320,40 @@ describe("precedence and shape", () => {
   });
 });
 
-describe("known defect, pinned so a fix is deliberate", () => {
-  // quickBirthControl.ts:50 inserts a Day with notes = null (insertDay writes
-  // `notes ?? null`). The Notes rule tests `day.notes === ""`, so null reads as
-  // "has notes" and the day gets a marker it never earned. Behaviour is moved
-  // here verbatim; fixing it is a separate change, and this test is what will
-  // fail loudly when someone makes it.
-  it("currently marks a Day whose notes column is null", () => {
+describe("what counts as having notes", () => {
+  // The `days.notes` column is nullable and insertDay writes `notes ?? null`,
+  // so a Day logged through quickBirthControl has null here, not "". This rule
+  // used to test `notes === ""` and marked every such Day.
+  it.each([
+    ["null", null],
+    ["empty", ""],
+    ["whitespace", "   "],
+  ])("draws a spacer when notes are %s", (_label, notes) => {
+    const marked = build({
+      filters: ["Notes"],
+      days: [day("2026-08-01", { notes })],
+    });
+
+    expect(marked["2026-08-01"].periods).toEqual([{ color: "transparent" }]);
+  });
+
+  it("draws a marker for real text", () => {
+    const marked = build({
+      filters: ["Notes"],
+      days: [day("2026-08-01", { notes: "cramping" })],
+    });
+
+    expect(marked["2026-08-01"].periods[0].color).toBe(SpecialtyFilterColor);
+  });
+
+  it("agrees with the pregnancy builder on what blank means", () => {
+    // Both modes have their own marking rules by ADR 0001, but "has notes" is
+    // one question and they answered it two ways.
     const marked = build({
       filters: ["Notes"],
       days: [day("2026-08-01", { notes: null })],
     });
 
-    expect(marked["2026-08-01"].periods[0].color).toBe(SpecialtyFilterColor);
+    expect(marked["2026-08-01"].periods[0].color).toBe("transparent");
   });
 });

--- a/services/__tests__/exportRows.test.ts
+++ b/services/__tests__/exportRows.test.ts
@@ -1,0 +1,204 @@
+import {
+  birthControlDetail,
+  csvField,
+  groupEntriesByMonth,
+  toCsv,
+} from "@/services/exportRows";
+import type { ExportData, ExportDayEntry } from "@/constants/Interfaces";
+
+const entry = (
+  date: string,
+  overrides: Partial<ExportDayEntry> = {},
+): ExportDayEntry => ({
+  date,
+  flow_intensity: 0,
+  notes: "",
+  moods: [],
+  symptoms: [],
+  medications: [],
+  birth_control: [],
+  ...overrides,
+});
+
+const headers: ExportData["headers"] = {
+  base_header: ["date", "flow_intensity", "notes"],
+  symptoms: ["Cramps"],
+  moods: ["Happy"],
+  medications: ["Ibuprofen"],
+  birth_control: ["Pill"],
+};
+
+describe("csvField", () => {
+  it("quotes a plain value", () => {
+    expect(csvField("cramping")).toBe('"cramping"');
+  });
+
+  it("escapes an embedded quote by doubling it", () => {
+    // The rule was `"${value}"` with no escaping, so a note containing a quote
+    // ended its field early and shifted every column after it on that row.
+    expect(csvField('she said "ok", then left')).toBe(
+      '"she said ""ok"", then left"',
+    );
+  });
+
+  it("keeps a comma inside the field", () => {
+    expect(csvField("one, two")).toBe('"one, two"');
+  });
+
+  it("keeps a newline inside the field", () => {
+    expect(csvField("line one\nline two")).toBe('"line one\nline two"');
+  });
+
+  it("renders an absent value as an empty field", () => {
+    expect(csvField(undefined)).toBe('""');
+    expect(csvField("")).toBe('""');
+  });
+});
+
+describe("birthControlDetail", () => {
+  it("gives the time when only a time is recorded", () => {
+    expect(birthControlDetail({ name: "Pill", time_taken: "08:00" })).toBe(
+      "Time: 08:00",
+    );
+  });
+
+  it("gives the notes when only notes are recorded", () => {
+    expect(birthControlDetail({ name: "Pill", notes: "with food" })).toBe(
+      "Notes: with food",
+    );
+  });
+
+  it("joins both with a comma", () => {
+    expect(
+      birthControlDetail({
+        name: "Pill",
+        time_taken: "08:00",
+        notes: "with food",
+      }),
+    ).toBe("Time: 08:00, Notes: with food");
+  });
+
+  it("is empty when neither is recorded", () => {
+    expect(birthControlDetail({ name: "Pill" })).toBe("");
+  });
+});
+
+describe("toCsv", () => {
+  it("writes a header row from the Catalogue names", () => {
+    const [header] = toCsv({ headers, dailyData: {} }).split("\n");
+
+    expect(header).toBe(
+      "date,flow_intensity,notes,symptom.Cramps,mood.Happy,medication.Ibuprofen,birth_control.Pill,birth_control.Pill.notes",
+    );
+  });
+
+  it("marks what was logged and leaves the rest blank", () => {
+    const csv = toCsv({
+      headers,
+      dailyData: {
+        "2026-08-01": entry("2026-08-01", {
+          flow_intensity: 3,
+          symptoms: ["Cramps"],
+          medications: [{ name: "Ibuprofen" }],
+        }),
+      },
+    });
+    const row = csv.split("\n")[1].split(",");
+
+    expect(row[1]).toBe("3");
+    expect(row[3]).toBe("x"); // symptom.Cramps
+    expect(row[4]).toBe(""); // mood.Happy
+    expect(row[5]).toBe("x"); // medication.Ibuprofen
+    expect(row[6]).toBe(""); // birth_control.Pill
+  });
+
+  it("survives a note containing a quote and a comma", () => {
+    // Before escaping, this row gained columns and the file no longer parsed.
+    const csv = toCsv({
+      headers,
+      dailyData: {
+        "2026-08-01": entry("2026-08-01", { notes: 'said "ok", then left' }),
+      },
+    });
+    const row = csv.split("\n")[1];
+
+    expect(row).toContain('"said ""ok"", then left"');
+    expect(csv.split("\n")[0].split(",")).toHaveLength(8);
+  });
+
+  it("puts the birth control detail in its own field", () => {
+    const csv = toCsv({
+      headers,
+      dailyData: {
+        "2026-08-01": entry("2026-08-01", {
+          birth_control: [
+            { name: "Pill", time_taken: "08:00", notes: "with food" },
+          ],
+        }),
+      },
+    });
+
+    expect(csv.split("\n")[1]).toContain('"Time: 08:00, Notes: with food"');
+  });
+});
+
+describe("groupEntriesByMonth", () => {
+  it("groups by calendar month, newest month first", () => {
+    const groups = groupEntriesByMonth([
+      entry("2026-03-04"),
+      entry("2026-08-15"),
+      entry("2026-05-20"),
+    ]);
+
+    expect(groups.map((g) => g.key)).toEqual(["2026-08", "2026-05", "2026-03"]);
+  });
+
+  it("orders the days within a month oldest first", () => {
+    const groups = groupEntriesByMonth([
+      entry("2026-08-31"),
+      entry("2026-08-01"),
+      entry("2026-08-15"),
+    ]);
+
+    expect(groups[0].entries.map((e) => e.date)).toEqual([
+      "2026-08-01",
+      "2026-08-15",
+      "2026-08-31",
+    ]);
+  });
+
+  it("does not confuse the same month in different years", () => {
+    const groups = groupEntriesByMonth([
+      entry("2025-08-01"),
+      entry("2026-08-01"),
+    ]);
+
+    expect(groups.map((g) => g.key)).toEqual(["2026-08", "2025-08"]);
+  });
+
+  it("orders by the date, not by a localised label", () => {
+    // The key used to be `toLocaleString("default", {month:"long", year:"numeric"})`
+    // parsed back through an English-only lookup table. On a French device that
+    // produced "août 2026", on Spanish "agosto de 2026", and the sort key came
+    // out NaN -- so month order in an exported PDF was undefined for anyone not
+    // running an English locale. The key is derived from the date now.
+    const groups = groupEntriesByMonth([
+      entry("2026-01-05"),
+      entry("2026-12-05"),
+      entry("2026-06-05"),
+    ]);
+
+    expect(groups.map((g) => g.key)).toEqual(["2026-12", "2026-06", "2026-01"]);
+  });
+
+  it("still offers a human label for each group", () => {
+    const [group] = groupEntriesByMonth([entry("2026-08-15")]);
+
+    expect(group.label).toMatch(/2026/);
+    expect(group.label.length).toBeGreaterThan(4);
+  });
+
+  it("returns nothing for no entries", () => {
+    expect(groupEntriesByMonth([])).toEqual([]);
+  });
+});

--- a/services/__tests__/pregnancyMarkedDates.test.ts
+++ b/services/__tests__/pregnancyMarkedDates.test.ts
@@ -1,0 +1,208 @@
+import { buildPregnancyMarkedDates } from "@/services/pregnancyMarkedDates";
+import { AppointmentColor, SpecialtyFilterColor } from "@/constants/Colors";
+import type * as schema from "@/db/schema";
+
+/**
+ * The pregnancy marking rules, tested directly.
+ *
+ * ADR 0001 asked for the builder to be exported so the hook shell would be the
+ * only database-bound part. These are the rules that became reachable: the
+ * appointment dedupe, and the four point-event filters.
+ *
+ * Pregnancy marks are point events, not runs. Nothing here shares a rule with
+ * `services/cycleMarkedDates.ts`, and the two are deliberately not merged.
+ */
+
+let nextId = 1;
+
+function day(
+  date: string,
+  overrides: Partial<schema.PregnancyDay> = {},
+): schema.PregnancyDay {
+  return {
+    id: nextId++,
+    date,
+    symptoms: null,
+    moods: null,
+    kicks: null,
+    notes: null,
+    ...overrides,
+  } as schema.PregnancyDay;
+}
+
+function appointment(date: string): schema.PregnancyAppointment {
+  return { id: nextId++, date } as schema.PregnancyAppointment;
+}
+
+beforeEach(() => {
+  nextId = 1;
+});
+
+describe("appointments", () => {
+  it("marks a date that has one", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Appointments"],
+      [],
+      [appointment("2026-08-10")],
+    );
+
+    expect(marked["2026-08-10"].periods).toEqual([
+      { startingDay: true, endingDay: true, color: AppointmentColor },
+    ]);
+  });
+
+  it("draws one marker for a date with several appointments", () => {
+    // The dedupe rule. Two appointments on one day is ordinary, and without
+    // this the date would draw two identical bars.
+    const marked = buildPregnancyMarkedDates(
+      ["Appointments"],
+      [],
+      [
+        appointment("2026-08-10"),
+        appointment("2026-08-10"),
+        appointment("2026-08-10"),
+      ],
+    );
+
+    expect(marked["2026-08-10"].periods).toHaveLength(1);
+  });
+
+  it("draws nothing when the filter is off", () => {
+    const marked = buildPregnancyMarkedDates(
+      [],
+      [],
+      [appointment("2026-08-10")],
+    );
+
+    expect(marked["2026-08-10"]).toBeUndefined();
+  });
+});
+
+describe("the four day-level filters", () => {
+  it("marks Symptoms only when some are logged", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Symptoms"],
+      [
+        day("2026-08-01", { symptoms: JSON.stringify(["Nausea"]) }),
+        day("2026-08-02", { symptoms: JSON.stringify([]) }),
+        day("2026-08-03"),
+      ],
+      [],
+    );
+
+    expect(marked["2026-08-01"].periods).toHaveLength(1);
+    expect(marked["2026-08-01"].periods[0].color).toBe(SpecialtyFilterColor);
+    expect(marked["2026-08-02"].periods).toEqual([]);
+    expect(marked["2026-08-03"].periods).toEqual([]);
+  });
+
+  it("marks Moods only when some are logged", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Moods"],
+      [
+        day("2026-08-01", { moods: JSON.stringify(["Tired"]) }),
+        day("2026-08-02", { moods: JSON.stringify([]) }),
+      ],
+      [],
+    );
+
+    expect(marked["2026-08-01"].periods).toHaveLength(1);
+    expect(marked["2026-08-02"].periods).toEqual([]);
+  });
+
+  it("marks Kicks only for a positive count", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Kicks"],
+      [
+        day("2026-08-01", { kicks: 12 }),
+        day("2026-08-02", { kicks: 0 }),
+        day("2026-08-03", { kicks: null }),
+      ],
+      [],
+    );
+
+    expect(marked["2026-08-01"].periods).toHaveLength(1);
+    expect(marked["2026-08-02"].periods).toEqual([]);
+    expect(marked["2026-08-03"].periods).toEqual([]);
+  });
+
+  it("marks Notes only for non-blank text", () => {
+    // Note what this treats as absent: null, empty, and whitespace alike. The
+    // cycle builder tested `notes === ""` instead, which read a null column as
+    // having notes.
+    const marked = buildPregnancyMarkedDates(
+      ["Notes"],
+      [
+        day("2026-08-01", { notes: "felt movement" }),
+        day("2026-08-02", { notes: "" }),
+        day("2026-08-03", { notes: "   " }),
+        day("2026-08-04", { notes: null }),
+      ],
+      [],
+    );
+
+    expect(marked["2026-08-01"].periods).toHaveLength(1);
+    expect(marked["2026-08-02"].periods).toEqual([]);
+    expect(marked["2026-08-03"].periods).toEqual([]);
+    expect(marked["2026-08-04"].periods).toEqual([]);
+  });
+});
+
+describe("shape", () => {
+  it("stacks a marker per active filter on one date", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Symptoms", "Moods", "Kicks", "Notes"],
+      [
+        day("2026-08-01", {
+          symptoms: JSON.stringify(["Nausea"]),
+          moods: JSON.stringify(["Tired"]),
+          kicks: 3,
+          notes: "a note",
+        }),
+      ],
+      [],
+    );
+
+    expect(marked["2026-08-01"].periods).toHaveLength(4);
+  });
+
+  it("puts an appointment marker before the day's own markers", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Appointments", "Kicks"],
+      [day("2026-08-10", { kicks: 5 })],
+      [appointment("2026-08-10")],
+    );
+
+    expect(marked["2026-08-10"].periods.map((p) => p.color)).toEqual([
+      AppointmentColor,
+      SpecialtyFilterColor,
+    ]);
+  });
+
+  it("draws every mark as its own start and end, never a run", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Kicks"],
+      [day("2026-08-01", { kicks: 1 }), day("2026-08-02", { kicks: 1 })],
+      [],
+    );
+
+    for (const date of ["2026-08-01", "2026-08-02"]) {
+      expect(marked[date].periods[0]).toMatchObject({
+        startingDay: true,
+        endingDay: true,
+      });
+    }
+  });
+
+  it("does not write a selected key", () => {
+    const marked = buildPregnancyMarkedDates(
+      ["Appointments", "Kicks"],
+      [day("2026-08-01", { kicks: 2 })],
+      [appointment("2026-08-05")],
+    );
+
+    for (const entry of Object.values(marked)) {
+      expect(entry).not.toHaveProperty("selected");
+    }
+  });
+});

--- a/services/cycleMarkedDates.ts
+++ b/services/cycleMarkedDates.ts
@@ -286,7 +286,11 @@ function loggedMarkedDates(
     // notes
     const notesFilter = filters.includes("Notes");
     if (notesFilter) {
-      if (day.notes === "") {
+      // Blank is blank however it is stored. This tested `day.notes === ""`,
+      // and the column is nullable: insertDay writes `notes ?? null`, so a Day
+      // logged through db/quickBirthControl.ts got a note marker it never
+      // earned. services/pregnancyMarkedDates.ts already had this right.
+      if (!day.notes?.trim()) {
         markedDates[day.date].periods.push({
           color: "transparent",
         });

--- a/services/exportRows.ts
+++ b/services/exportRows.ts
@@ -1,0 +1,140 @@
+import type { ExportData, ExportDayEntry } from "@/constants/Interfaces";
+
+/**
+ * What one Day looks like in an export, above the format it is written in.
+ *
+ * The CSV and the PDF each composed a birth control cell their own way, and
+ * each had its own idea of how to order months, with neither reachable by a
+ * test: `formatJsonDataToCsv` was unexported in a file that imports
+ * `expo-sharing`, and the PDF's grouping ran inside the same function that
+ * writes the file and hands it to the share sheet.
+ */
+
+/** The name of a Medication, with whatever detail was recorded against it. */
+type LoggedMedication = {
+  name: string;
+  time_taken?: string;
+  notes?: string;
+};
+
+/**
+ * The time and notes recorded against a birth control Entry, as one phrase.
+ *
+ * This was written twice, with different labels and different separators:
+ * `Time Taken: {t} Notes: {n}` in the CSV and `Time: {t}, Notes: {n}` in the
+ * PDF. It is one fact about one Entry, so it reads the same in both now.
+ */
+export function birthControlDetail(medication: LoggedMedication): string {
+  const parts: string[] = [];
+  if (medication.time_taken) parts.push(`Time: ${medication.time_taken}`);
+  if (medication.notes) parts.push(`Notes: ${medication.notes}`);
+  return parts.join(", ");
+}
+
+/**
+ * One CSV field, quoted and escaped.
+ *
+ * Values were wrapped as `"${value}"` and never escaped. A note containing a
+ * quote ended its field early, so the row gained columns and everything after
+ * it shifted. Doubling the quote is what RFC 4180 asks for and what every
+ * spreadsheet expects.
+ */
+export function csvField(value: string | undefined | null): string {
+  return `"${(value ?? "").replace(/"/g, '""')}"`;
+}
+
+/** The whole export as CSV text: a header row, then one row per Day. */
+export function toCsv({ headers, dailyData }: ExportData): string {
+  const headerRow = [...headers.base_header];
+
+  for (const symptom of headers.symptoms) headerRow.push(`symptom.${symptom}`);
+  for (const mood of headers.moods) headerRow.push(`mood.${mood}`);
+  for (const medication of headers.medications) {
+    headerRow.push(`medication.${medication}`);
+  }
+  for (const birthControl of headers.birth_control) {
+    headerRow.push(`birth_control.${birthControl}`);
+    headerRow.push(`birth_control.${birthControl}.notes`);
+  }
+
+  const rows: string[] = [headerRow.join(",")];
+
+  for (const entry of Object.values(dailyData)) {
+    const row: string[] = [
+      entry.date,
+      String(entry.flow_intensity),
+      csvField(entry.notes),
+    ];
+
+    for (const symptom of headers.symptoms) {
+      row.push(entry.symptoms.includes(symptom) ? "x" : "");
+    }
+    for (const mood of headers.moods) {
+      row.push(entry.moods.includes(mood) ? "x" : "");
+    }
+    for (const medication of headers.medications) {
+      row.push(entry.medications.some((m) => m.name === medication) ? "x" : "");
+    }
+    for (const birthControl of headers.birth_control) {
+      const logged = entry.birth_control.find((bc) => bc.name === birthControl);
+      if (logged) {
+        row.push("x", csvField(birthControlDetail(logged)));
+      } else {
+        row.push("", "");
+      }
+    }
+
+    rows.push(row.join(","));
+  }
+
+  return rows.join("\n");
+}
+
+/** The Days of one calendar month, with a label to print above them. */
+export type MonthGroup = {
+  /** `YYYY-MM`. Sorts correctly as a string and does not depend on a locale. */
+  key: string;
+  /** For display only. Never parsed back. */
+  label: string;
+  /** Oldest first. */
+  entries: ExportDayEntry[];
+};
+
+const MONTH_LABEL_OPTIONS: Intl.DateTimeFormatOptions = {
+  month: "long",
+  year: "numeric",
+  timeZone: "UTC",
+};
+
+/**
+ * The Days grouped into calendar months, newest month first.
+ *
+ * The key is derived from the date rather than from a display label. It used to
+ * be `toLocaleString("default", { month: "long", year: "numeric" })`, which the
+ * sort then split on a space and looked up in an English-only table of month
+ * names. On a French device that label is "août 2026" and on a Spanish one
+ * "agosto de 2026", so the lookup returned undefined, `Date.UTC` returned NaN,
+ * and the comparator ordered the months arbitrarily. A label is for reading;
+ * it is not an identifier.
+ */
+export function groupEntriesByMonth(entries: ExportDayEntry[]): MonthGroup[] {
+  const byMonth = new Map<string, ExportDayEntry[]>();
+
+  for (const entry of entries) {
+    const key = entry.date.slice(0, 7);
+    const group = byMonth.get(key);
+    if (group) group.push(entry);
+    else byMonth.set(key, [entry]);
+  }
+
+  return [...byMonth.entries()]
+    .sort(([a], [b]) => b.localeCompare(a))
+    .map(([key, monthEntries]) => ({
+      key,
+      label: new Date(`${key}-01T00:00:00Z`).toLocaleString(
+        undefined,
+        MONTH_LABEL_OPTIONS,
+      ),
+      entries: [...monthEntries].sort((a, b) => a.date.localeCompare(b.date)),
+    }));
+}

--- a/services/pregnancyMarkedDates.ts
+++ b/services/pregnancyMarkedDates.ts
@@ -1,0 +1,103 @@
+import type { MarkedDates } from "@/constants/Interfaces";
+import { AppointmentColor, SpecialtyFilterColor } from "@/constants/Colors";
+import type * as schema from "@/db/schema";
+
+/**
+ * How each date should be drawn in pregnancy mode. See CONTEXT.md, Marked Dates.
+ *
+ * Pregnancy marks are point events: every one of them is its own start and end,
+ * with no runs and no adjacency. That is a different algorithm from cycle mode's
+ * producing the same value type, which is one of the three reasons
+ * `docs/adr/0001-keep-cycle-and-pregnancy-modes-separate.md` gives for the two
+ * not sharing a builder.
+ *
+ * Its own module because that ADR's Consequences section asked for the hook
+ * shell to be the only database-bound part. Exporting it in place was not
+ * enough: `hooks/usePregnancyMarkedDates.ts` opens the database at module
+ * scope, so importing the builder from there pulled expo-sqlite in and a test
+ * had to mock a database to exercise a pure function.
+ *
+ * This mirrors the placement of `services/cycleMarkedDates.ts`. The two share
+ * the file layout and the `MarkedDates` value type, and nothing else -- they
+ * are different algorithms, which is the ADR's second discriminator.
+ *
+ * `pregnancyDays` arrives in the storage shape, with `symptoms` and `moods` as
+ * JSON text, because `pregnancy_days` stores them that way.
+ */
+export function buildPregnancyMarkedDates(
+  filters: string[],
+  pregnancyDays: schema.PregnancyDay[],
+  appointments: schema.PregnancyAppointment[],
+): MarkedDates {
+  const markedDates: MarkedDates = {};
+
+  const appointmentsFilter = filters.includes("Appointments");
+  const symptomsFilter = filters.includes("Symptoms");
+  const moodsFilter = filters.includes("Moods");
+  const kicksFilter = filters.includes("Kicks");
+  const notesFilter = filters.includes("Notes");
+
+  // Build appointment markers (dots on dates that have appointments)
+  if (appointmentsFilter) {
+    for (const appt of appointments) {
+      if (!markedDates[appt.date]) {
+        markedDates[appt.date] = { periods: [] };
+      }
+      // Only add one appointment period per date even if multiple appointments exist
+      const alreadyHasAppt = markedDates[appt.date].periods.some(
+        (p) => p.color === AppointmentColor,
+      );
+      if (!alreadyHasAppt) {
+        markedDates[appt.date].periods.push({
+          startingDay: true,
+          endingDay: true,
+          color: AppointmentColor,
+        });
+      }
+    }
+  }
+
+  // Build day-level markers from pregnancyDays
+  for (const day of pregnancyDays) {
+    if (!markedDates[day.date]) {
+      markedDates[day.date] = { periods: [] };
+    }
+
+    const daySymptoms: string[] = day.symptoms ? JSON.parse(day.symptoms) : [];
+    const dayMoods: string[] = day.moods ? JSON.parse(day.moods) : [];
+
+    if (symptomsFilter && daySymptoms.length > 0) {
+      markedDates[day.date].periods.push({
+        startingDay: true,
+        endingDay: true,
+        color: SpecialtyFilterColor,
+      });
+    }
+
+    if (moodsFilter && dayMoods.length > 0) {
+      markedDates[day.date].periods.push({
+        startingDay: true,
+        endingDay: true,
+        color: SpecialtyFilterColor,
+      });
+    }
+
+    if (kicksFilter && day.kicks != null && day.kicks > 0) {
+      markedDates[day.date].periods.push({
+        startingDay: true,
+        endingDay: true,
+        color: SpecialtyFilterColor,
+      });
+    }
+
+    if (notesFilter && day.notes && day.notes.trim() !== "") {
+      markedDates[day.date].periods.push({
+        startingDay: true,
+        endingDay: true,
+        color: SpecialtyFilterColor,
+      });
+    }
+  }
+
+  return markedDates;
+}


### PR DESCRIPTION
Two follow-ups from the 2026-08-21 architecture review, after #250.

## `13b49ca` — the pregnancy Marked Dates rules get a seam

ADR 0001's Consequences section asked for the pure builder in `usePregnancyMarkedDates` to be exported, so the hook shell would be the only database-bound part. Exporting it in place turned out not to be enough: the hook opens the database at module scope, so importing the builder pulled `expo-sqlite` in and a test had to mock a database to exercise a pure function. It moves to `services/pregnancyMarkedDates.ts` instead, mirroring where `services/cycleMarkedDates.ts` sits.

**That is placement, not sharing.** The two builders have the file layout and the `MarkedDates` value type in common and nothing else. Cycle marks encode runs with caps and adjacency; pregnancy marks are point events, every one its own start and end. That is ADR 0001's second discriminator and it still holds — nothing here merges the modes or introduces a mode conditional.

Eleven tests, none needing a database. The appointment dedupe is the one worth naming: two appointments on one day is ordinary, and without that rule the date draws two identical bars.

**This also finishes candidate 09.** The selected-tracking effect is deleted — dead the same way the cycle one was, since the calendar screen overwrites the field unconditionally at render.

That resolves the follow-up flagged at the end of #250. `MarkedDate.selected` was optional with cycle mode no longer writing it and pregnancy mode still doing so, and that asymmetry sat on a type ADR 0001 names as shared surface. Neither mode writes it now — `grep` finds exactly two writers, both calendar screens, both at render — so there is no longer a decision to record and no ADR needed.

## `d7c96d1` — the Notes filter marked Days that had no notes

The rule tested `day.notes === ""`. The column is nullable and `insertDay` writes `notes ?? null`, so a Day created by `db/quickBirthControl.ts` — logging birth control from the home screen, which passes no notes — came back with `null` and drew a note marker for a note that was never written.

`services/pregnancyMarkedDates.ts` already had this right (`notes && notes.trim() !== ""`). Both modes keep their own marking rules, but "does this Day have notes" is one question and they were answering it two ways. Now they agree, and whitespace-only notes count as blank on both sides.

The rule was moved **verbatim** in `cf5ead9` and pinned by a test named as a known defect, precisely so the fix would be a deliberate change rather than a side effect of a refactor. This is that change; the test now asserts the correct behaviour.

The sibling filters were checked and are **not** affected — `is_cycle_start`, `is_cycle_end` and `intercourse` are `.default(false)` and `insertDay` passes them through, so an omitted value takes the default rather than writing null. Confirmed by probing what the database actually stores, not by reading the schema.

## Verification

`npm test`, `npm run typecheck`, `npm run lint` all pass. 363 → **378** tests.

Both behaviour changes were confirmed by reverting them and watching the new tests fail: restoring `day.notes === ""` fails three of the new cases.

Not smoke-tested on a simulator — both changes are covered directly by unit tests, and the marking rules now have a real one on the pregnancy side for the first time.

## Still open from the review

Candidate 10, the export row model, where `ExportData.tsx` and `PdfBuilder.ts` compose a birth-control cell two different ways. Left out deliberately: it touches two untested files and has an I/O tail to move, so it deserves its own scope decision.