### PR TITLE
Read the database only after migrations, and stop the filter conversion wiping current data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,35 +4,71 @@ Welcome to the Ephira project! We welcome contributions from our team members an
 
 ## 1. Prerequisites & Setup
 
-To run the project locally, you need:
+**This project cannot run in Expo Go.** It uses config plugins that change the
+native projects, and Expo Go ships one fixed native runtime that has none of
+them:
+
+- `expo-sqlite` with `useSQLCipher: true` — an encrypted SQLite build, not the
+  stock library Expo Go carries
+- `expo-local-authentication` — needs `NSFaceIDUsageDescription` in an
+  `Info.plist` that is ours
+- `plugins/withAndroid16KBSupport.js` — a local config plugin, so by definition
+  not compiled into anything published
+
+You need a **development build** on a simulator, an emulator or a device. To
+run it locally you need:
 
 - Node.js (LTS version)
-- Expo Go app on your physical device (iOS/Android)
-- VS Code (recommended) with ESLint/Prettier extensions
+- Xcode with a simulator (iOS), or Android Studio with an emulator (Android)
+- CocoaPods, for the iOS build
+- VS Code (recommended)
 
 ### Installation
 
-1.  **Clone the repo:**
-    ```bash
-    git clone [https://github.com/adulbrich/ephira.git](https://github.com/adulbrich/ephira.git)
-    cd ephira
-    ```
-2.  **Install dependencies:**
-    ```bash
-    npm install
-    ```
-3.  **Start the project:**
-    ```bash
-    npx expo start
-    ```
+1. **Clone the repo:**
+
+   ```bash
+   git clone https://github.com/adulbrich/ephira.git
+   cd ephira
+   ```
+
+2. **Install dependencies:**
+
+   ```bash
+   npm install
+   ```
+
+3. **Build and run:**
+
+   ```bash
+   npm run ios      # or: npm run android
+   ```
+
+   This runs `expo run:ios`, which generates the native projects with
+   [`expo prebuild`](https://docs.expo.dev/workflow/prebuild/) and compiles a
+   development build. **The first run is slow** — it compiles every native
+   dependency from scratch. Later runs are incremental.
+
+4. **Day to day:**
+
+   ```bash
+   npm start
+   ```
+
+   Once a development build is installed, `expo start` is all a JavaScript
+   change needs. Rebuild only when something native changes: a dependency with
+   native code, anything in `app.json`, or anything in `plugins/`.
+
+`/ios` and `/android` are generated output and are gitignored. Edit `app.json`
+and `plugins/` instead; prebuild rebuilds the native projects from them.
 
 ## 2. Local Quality Checks
 
-Before opening a Pull Request, run these commands to ensure your code meets our standards:
+Before opening a Pull Request, run what CI runs:
 
-- **Linting:** `npm run lint` (Fixes syntax/style errors)
-- **Formatting:** `npm run format` (Ensures code style consistency)
-- **Type Check:** `npm run tsc` (Checks TypeScript errors)
+- **Lint and format:** `npm run lint` (`npm run format` fixes what is fixable)
+- **Type check:** `npm run typecheck`
+- **Tests:** `npm test`
 
 ## 3. Contribution Workflow
 
@@ -50,12 +86,12 @@ We follow the **Feature Branch Workflow**.
 4.  **Code Review:**
     - Assign at least one team member to review.
     - Address all comments.
-    - **Requirement:** All CI checks (Lint/Build) must pass.
+    - **Requirement:** All CI checks must pass (lint, typecheck, tests).
 
 ## 4. Definition of Done (DoD)
 
-- [ ] Code compiles/runs without errors on Expo Go (Standard Mode).
-- [ ] No linting warnings.
+- [ ] Runs without errors on a simulator, emulator or device.
+- [ ] `npm run lint`, `npm run typecheck` and `npm test` all pass.
 - [ ] Feature satisfies the Acceptance Criteria in the linked Issue.
 - [ ] PR has 1 approval.
 

--- a/PROJECTSTRUCTURE.md
+++ b/PROJECTSTRUCTURE.md
@@ -114,19 +114,25 @@ owns the rules, which is what makes those rules testable without rendering.
 
 ## Setup
 
-Due to using Expo SQLite for the database, this project will only run on mobile devices or emulators.
+This project cannot run in [Expo Go](https://expo.dev/go). It uses config
+plugins that change the native projects -- `expo-sqlite` with SQLCipher,
+`expo-local-authentication`, `expo-notifications`, and the local
+`plugins/withAndroid16KBSupport.js` -- and Expo Go ships a fixed native runtime
+that has none of them. It needs a simulator, an emulator or a device.
 
 - Clone the repo
 - `npm install` (Node.js LTS recommended)
-- `npx expo start`
+- `npm run ios` or `npm run android`
 
-In the output, you'll find options to open the app in a:
+Those run `expo run:ios` / `expo run:android`, which generate the native
+projects with [`expo prebuild`](https://docs.expo.dev/workflow/prebuild/) and
+build a [development build](https://docs.expo.dev/develop/development-builds/introduction/).
+The first build is slow; later ones are incremental. `/ios` and `/android` are
+generated output and are gitignored -- edit `app.json` and `plugins/` instead,
+and prebuild rebuilds from them.
 
-- [development build](https://docs.expo.dev/develop/development-builds/introduction/)
-- [Android emulator](https://docs.expo.dev/workflow/android-studio-emulator/)
-- [iOS simulator](https://docs.expo.dev/workflow/ios-simulator/)
-- [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
-  - If you get an error about the app not being able to connect or taking longer than it should, try running `npx expo start --tunnel` in the terminal and scanning the QR code again.
+Once a development build is installed, `npx expo start` is enough for
+JavaScript changes; you only need to rebuild when something native changes.
 
 This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,20 @@ We welcome contributions! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for gui
 git clone https://github.com/adulbrich/ephira.git
 cd ephira
 npm install
-npx expo start
+npm run ios      # or: npm run android
 ```
+
+The first run compiles a development build, which takes a while. After that,
+`npm start` is enough for JavaScript changes.
 
 See [PROJECTSTRUCTURE.md](PROJECTSTRUCTURE.md) for an overview of the codebase, key libraries, and local setup instructions.
 
-> **Note:** Due to using Expo SQLite, the app only runs on physical devices or emulators (not Expo web).
+> **Note:** ephira **cannot run in Expo Go**, and does not run on the web. It
+> uses config plugins that change the native projects — SQLCipher-backed
+> storage, biometric authentication, and a local Android plugin — and Expo Go
+> ships a fixed native runtime that has none of them. You need a development
+> build on a simulator, an emulator or a device. See
+> [CONTRIBUTING.md](CONTRIBUTING.md) for the full setup.
 
 ## Acknowledgments
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -61,7 +61,19 @@ export default function RootLayout() {
   const { setPredictionChoice } = usePredictionChoice();
   const { setSelectedFilters } = useCalendarFilters();
 
+  const expoDb = getDatabase();
+  const db = getDrizzleDatabase();
+  useDrizzleStudio(expoDb);
+  // Nothing below may read the database until this reports success. The tables
+  // do not exist before it, so on a fresh install every read here rejected --
+  // five unhandled rejections, and neither durable preference hydrated, so a
+  // new user got neither their default calendar filters nor a prediction
+  // choice on record.
+  const { success, error } = useMigrations(db, migrations);
+
   useEffect(() => {
+    if (!success) return;
+
     async function fetchThemeColor() {
       const savedTheme = await getSetting("theme");
       if (savedTheme?.value) {
@@ -71,27 +83,31 @@ export default function RootLayout() {
       }
     }
     fetchThemeColor();
-  }, [setThemeColor]);
+  }, [setThemeColor, success]);
 
   useEffect(() => {
+    if (!success) return;
+
     async function fetchTrackingMode() {
       const saved = await getSetting(SettingsKeys.trackingMode);
       setTrackingMode(saved?.value ?? TRACKING_MODES.CYCLE);
     }
     fetchTrackingMode();
-  }, [setTrackingMode]);
+  }, [setTrackingMode, success]);
 
   // Durable preferences hydrate in the shell, not on the screen that happens
   // to need them first. These were loaded by the Calendar tab, so any screen
   // reached before it read a store still holding its initial value: the Cycle
   // tab told users predictions were off when their setting said on.
   useEffect(() => {
+    if (!success) return;
     loadCyclePredictionChoice().then(setPredictionChoice);
-  }, [setPredictionChoice]);
+  }, [setPredictionChoice, success]);
 
   useEffect(() => {
+    if (!success) return;
     loadCalendarFilters().then(setSelectedFilters);
-  }, [setSelectedFilters]);
+  }, [setSelectedFilters, success]);
 
   const finalSelectedColor = themeColor as
     | "blue"
@@ -102,10 +118,6 @@ export default function RootLayout() {
     | "yellow";
   const theme = getTheme(finalSelectedColor, isDarkMode);
 
-  const expoDb = getDatabase();
-  const db = getDrizzleDatabase();
-  useDrizzleStudio(expoDb);
-  const { success, error } = useMigrations(db, migrations);
   const [loaded] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
   });
@@ -174,6 +186,10 @@ export default function RootLayout() {
   }, [checkAuthentication]);
 
   useEffect(() => {
+    // The gate used to sit around checkAuthentication only, so the seeding
+    // above it ran on every mount whether the tables existed or not.
+    if (!success) return;
+
     const initializeDatabase = async () => {
       const isDatabaseSetup = await getSetting(
         SettingsKeys.databaseInitialSetup,
@@ -183,12 +199,14 @@ export default function RootLayout() {
         await insertSetting(SettingsKeys.databaseInitialSetup, "0000");
       }
 
-      if (loaded && success) {
+      if (loaded) {
         checkAuthentication();
       }
     };
 
-    initializeDatabase();
+    initializeDatabase().catch((err) => {
+      console.error("Database initialisation failed:", err);
+    });
   }, [loaded, success, checkAuthentication]);
 
   const handlePasswordSubmit = async (passwordInput: string) => {

--- a/db/__tests__/preferences.test.ts
+++ b/db/__tests__/preferences.test.ts
@@ -4,6 +4,7 @@ import {
   loadCyclePredictionChoice,
 } from "@/db/preferences";
 import { getSetting, insertSetting } from "@/db/operations/settings";
+import * as settingsOperations from "@/db/operations/settings";
 import { SettingsKeys } from "@/constants/Settings";
 import { resetTestDatabase } from "@/__tests__/helpers/testDatabase";
 
@@ -78,5 +79,34 @@ describe("loadCalendarFilters", () => {
     await insertSetting(SettingsKeys.calendarFilters, "{not json");
 
     expect(await loadCalendarFilters()).toEqual([...DEFAULT_CALENDAR_FILTERS]);
+  });
+});
+
+describe("when the database cannot be read", () => {
+  // The app shell calls these before anything has rendered. A rejection there
+  // is an uncaught error with nowhere to go, which is what happened on a fresh
+  // install while the tables were still being created.
+  const failing = () => {
+    jest
+      .spyOn(settingsOperations, "getSetting")
+      .mockRejectedValue(new Error("no such table: settings"));
+  };
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("falls back to the default calendar filters rather than rejecting", async () => {
+    failing();
+
+    await expect(loadCalendarFilters()).resolves.toEqual([
+      ...DEFAULT_CALENDAR_FILTERS,
+    ]);
+  });
+
+  it("falls back to the default prediction choice rather than rejecting", async () => {
+    failing();
+
+    await expect(loadCyclePredictionChoice()).resolves.toBe(true);
   });
 });

--- a/db/__tests__/setupEntryTypes.test.ts
+++ b/db/__tests__/setupEntryTypes.test.ts
@@ -1,4 +1,6 @@
 import { setupEntryTypes } from "@/db/database";
+import { getSetting, insertSetting } from "@/db/operations/settings";
+import { SettingsKeys } from "@/constants/Settings";
 import {
   days,
   medicationEntries,
@@ -16,6 +18,12 @@ import {
 jest.mock("@/db/operations/setup", () =>
   jest.requireActual("@/__tests__/helpers/testDatabase"),
 );
+
+/** What is actually on disk for the calendar filters. */
+async function storedFilters(): Promise<string[] | null> {
+  const stored = await getSetting(SettingsKeys.calendarFilters);
+  return stored?.value ? JSON.parse(stored.value) : null;
+}
 
 /**
  * Stands in for an upgrading user's database: a logged day with a mood, a
@@ -145,5 +153,51 @@ describe("setupEntryTypes on an already-populated database", () => {
         .all()
         .map((d) => d.date),
     ).toEqual(["2026-03-01"]);
+  });
+});
+
+describe("the legacy calendar filter conversion", () => {
+  // setupEntryTypes carries a one-time conversion from the old filter format,
+  // where a filter was an object with a `label`, to the plain strings used now.
+  it("converts filters still stored in the old object format", async () => {
+    await insertSetting(
+      SettingsKeys.calendarFilters,
+      JSON.stringify([{ label: "Flow" }, { label: "Notes" }]),
+    );
+
+    await setupEntryTypes();
+
+    expect(await storedFilters()).toEqual(["Flow", "Notes"]);
+  });
+
+  it("leaves filters already in the current format alone", async () => {
+    // This wiped them. Every entry is a string, so `filter.label` is undefined
+    // for all of them, the converted list came out empty, and it was written
+    // back over the real one. It only stayed hidden because the shell's
+    // hydration used to reject before anything was ever stored -- fixing that
+    // is what exposed it, and a new user's default filters were the first
+    // casualty.
+    await insertSetting(
+      SettingsKeys.calendarFilters,
+      JSON.stringify(["Flow", "Any Birth Control"]),
+    );
+
+    await setupEntryTypes();
+
+    expect(await storedFilters()).toEqual(["Flow", "Any Birth Control"]);
+  });
+
+  it("leaves an empty selection alone", async () => {
+    await insertSetting(SettingsKeys.calendarFilters, JSON.stringify([]));
+
+    await setupEntryTypes();
+
+    expect(await storedFilters()).toEqual([]);
+  });
+
+  it("writes nothing when no filters are stored", async () => {
+    await setupEntryTypes();
+
+    expect(await getSetting(SettingsKeys.calendarFilters)).toBeUndefined();
   });
 });

--- a/db/database.ts
+++ b/db/database.ts
@@ -199,23 +199,38 @@ export const setupEntryTypes = async () => {
     await insertMedication(birthControl, true, "birth control");
   }
 
-  // update calendar filters
+  // Convert calendar filters still stored in the old format, where a filter was
+  // an object with a `label` rather than the plain string used now.
+  //
+  // The conversion used to run against whatever was stored, not only against
+  // the old format. Every entry in a current list is a string, so `filter.label`
+  // was undefined for all of them, the converted list came out empty, and it
+  // was written back over the real one. It stayed hidden because the app shell
+  // read this setting before migrations had created the table, so the read
+  // rejected and nothing was ever stored for this to destroy.
   const storedFilters = await getSetting(SettingsKeys.calendarFilters);
-  const newFilters: string[] = [];
+  if (!storedFilters?.value) return;
 
-  if (storedFilters?.value) {
-    const currentFilters = JSON.parse(storedFilters.value); // Parse the stored string
-
-    for (const filter of currentFilters) {
-      if (filter.label) {
-        newFilters.push(filter.label);
-      }
-    }
-    await updateSetting(
-      SettingsKeys.calendarFilters,
-      JSON.stringify(newFilters),
-    );
+  let currentFilters: unknown;
+  try {
+    currentFilters = JSON.parse(storedFilters.value);
+  } catch {
+    return; // a corrupt preference is not this function's to repair
   }
+
+  if (!Array.isArray(currentFilters)) return;
+
+  const isLegacyFilter = (filter: unknown): filter is { label: string } =>
+    typeof filter === "object" &&
+    filter !== null &&
+    typeof (filter as { label?: unknown }).label === "string";
+
+  if (!currentFilters.some(isLegacyFilter)) return;
+
+  await updateSetting(
+    SettingsKeys.calendarFilters,
+    JSON.stringify(currentFilters.filter(isLegacyFilter).map((f) => f.label)),
+  );
 };
 
 export * from "@/db/operations/settings";

--- a/db/preferences.ts
+++ b/db/preferences.ts
@@ -28,25 +28,37 @@ export const DEFAULT_CALENDAR_FILTERS = ["Flow", "Any Birth Control"] as const;
  * A stored value that will not parse falls back to the default rather than
  * throwing. It is a corrupt preference, not a reason to fail a screen, and
  * the previous inline versions of this would have rejected inside an effect.
+ *
+ * So does a value that cannot be read at all. The caller is the app shell,
+ * which has no useful way to handle a rejection from a preference read.
  */
 async function loadJsonSetting<T>(
   key: string,
   fallback: T,
   isValid: (value: unknown) => value is T,
 ): Promise<T> {
-  const stored = await getSetting(key);
+  try {
+    const stored = await getSetting(key);
 
-  if (stored?.value !== undefined && stored?.value !== null) {
-    try {
-      const parsed: unknown = JSON.parse(stored.value);
-      if (isValid(parsed)) return parsed;
-    } catch {
-      // fall through to the default
+    if (stored?.value !== undefined && stored?.value !== null) {
+      try {
+        const parsed: unknown = JSON.parse(stored.value);
+        if (isValid(parsed)) return parsed;
+      } catch {
+        // fall through to the default
+      }
     }
-  }
 
-  await insertSetting(key, JSON.stringify(fallback));
-  return fallback;
+    await insertSetting(key, JSON.stringify(fallback));
+    return fallback;
+  } catch (error) {
+    // A preference that cannot be read is not a reason to leave a promise
+    // unhandled. These are called from the app shell, so a rejection surfaced
+    // as an uncaught error before anything had rendered. Same view this
+    // already took of a value that will not parse.
+    console.error(`Could not load the ${key} preference:`, error);
+    return fallback;
+  }
 }
 
 export function loadCyclePredictionChoice(): Promise<boolean> {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web",
     "test": "jest",
     "lint": "biome check . && eslint . --max-warnings=0",


### PR DESCRIPTION
Closes #249.

## `b404017` — the five racing reads

On a fresh install the app threw five unhandled rejections before it finished launching, all `no such table: settings`. The shell reads the database in five places and none waited on `useMigrations`:

| read | what it is |
| --- | --- |
| `getSetting("theme")` | saved theme colour |
| `getSetting(trackingMode)` | which mode to mount |
| `loadCyclePredictionChoice()` | durable preference |
| `loadCalendarFilters()` | durable preference |
| `getSetting(databaseInitialSetup)` | and `setupEntryTypes()` behind it |

The issue named the two preference loaders, because those were the two with recognisable stack frames. Counting the reads accounts for all five errors.

**The last one was the worst.** Its effect gated only `checkAuthentication` on `loaded && success`, so the seeding above it — `getSetting`, `setupEntryTypes` and `insertSetting` — ran on every mount whether the tables existed or not. The gate moves to the top of the effect, where it was doing no work.

`useMigrations` moves above the effects that depend on it, so the ordering is visible in the file rather than implied by a dependency array.

The consequence was not only noise: both loaders write their default down when nothing is stored, and neither write happened, so a new user had no calendar filters and no prediction choice on record.

`loadJsonSetting` also stops rejecting when a read fails and returns the default instead — the view it already took of a value that will not parse. Its callers are in the app shell and have nowhere to handle a rejection.

## `289f21a` — the fix exposed a data-destroying bug

`setupEntryTypes` carries a one-time conversion from the old calendar filter format, where a filter was an object with a `label`, to the plain strings used now. **It ran against whatever was stored, not only against the old format.** Every entry in a current list is a string, so `filter.label` was undefined for all of them, the converted list came out empty, and it was written back over the real one.

It only stayed hidden because of the first defect: the shell's read rejected, nothing was ever stored, and `storedFilters?.value` was falsy. Fixing the hydration is what exposed it — and a new user's default filters were the first casualty.

Verified on a simulator. Before `289f21a`, a fresh install came up with `calendarFilters = []`. After both commits it comes up with `["Flow","Any Birth Control"]`, which is what `DEFAULT_CALENDAR_FILTERS` says a new user should see.

## `<scripts>` — `npm run ios` pointed at a runtime that cannot run this app

Separable from the fix; it is here because verifying the fix is what surfaced it. `npm run ios` ran `expo start --ios`, which targets Expo Go. This app has not been able to run in Expo Go since **2024-11-26**, the day after it was scaffolded, when SQLCipher was turned on.

Expo Go is one prebuilt binary with a fixed set of native modules and no way to load native code at runtime. This project needs native code it does not contain: the local `plugins/withAndroid16KBSupport.js` config plugin, `expo-sqlite` with `useSQLCipher: true`, and `expo-local-authentication`'s `NSFaceIDUsageDescription`.

The scripts came from the `create-expo-app` template in `637332d` and were never revisited as those requirements accumulated. `expo prebuild` rewrites them to `expo run:*` on every local build, which is why this kept showing up as an unexplained diff — prebuild was correcting the same stale line each time and each of us reverted it. Adopting the correction makes prebuild idempotent.

The setup instructions offered Expo Go as an option, which cannot have worked. They now say what the first run needs. `npm start` is untouched.

## Verification

`npm test`, `npm run typecheck`, `npm run lint` all pass. 397 → **403** tests.

Both fixes confirmed by reverting them and watching the new tests fail. Smoke-tested on an iOS simulator from a wiped database: **five errors before, zero after**, with the right defaults on record.