### PR TITLE
Note the two things the Android setup actually needs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,14 @@ run it locally you need:
    npm run ios      # or: npm run android
    ```
 
+   For Android, **start the emulator first and let it finish booting.**
+   `expo run:android` installs over adb, and adb reports
+   `cmd: Can't find service: package` if the package manager is not up yet.
+   `adb shell getprop sys.boot_completed` returns `1` when it is ready.
+
+   Android also needs `ANDROID_HOME` pointing at your SDK. Android Studio sets
+   it; a shell that has never run it may not have it.
+
    This runs `expo run:ios`, which generates the native projects with
    [`expo prebuild`](https://docs.expo.dev/workflow/prebuild/) and compiles a
    development build. **The first run is slow** — it compiles every native


### PR DESCRIPTION
The Android half of the setup instructions in #253 was written from the iOS run and reasoning about the toolchain, not from doing it. I flagged that at the time. Doing it turned up two things worth saying.

**The emulator has to be booted before `npm run android`, not merely launched.** `expo run:android` installs over adb, and adb fails with `cmd: Can't find service: package` if the package manager service is not up yet. That happened on the first attempt here — Gradle finished successfully, then the install failed, and the error says nothing about the emulator still booting. `adb shell getprop sys.boot_completed` returns `1` when it is ready.

**`ANDROID_HOME` has to be set.** Android Studio sets it, so anyone who has used it will not notice; a shell that has not will.

## What the run showed

Verified on a Pixel emulator running API 34:

- `BUILD SUCCESSFUL in 7m 17s`, 429 tasks
- App installs, launches, bundle loads (2933 modules)
- A cleared data directory comes up with **zero errors** and `calendarFilters = ["Flow","Any Birth Control"]` on record — the #249 fixes behave the same on Android as on iOS
- Catalogue seeded, 13 tables present

## Two things I could not verify

**The 16 KB page path is untested.** `plugins/withAndroid16KBSupport.js` targets Android 15+, and the only system image installed locally is `android-34` (Android 14). The `Pixel_8a` AVD references an `android-36` image that is not installed and panics on launch, so it could not be used.

**`JAVA_HOME` unset is untested.** It is unset in a normal shell here, but I exported it for the build rather than finding out whether Gradle resolves Java 17 from `PATH` on its own. The docs make no claim about it either way.