### PR TITLE
Grant GITHUB_TOKEN only what the workflows use

### DIFF
--- a/.github/workflows/format-test.yml
+++ b/.github/workflows/format-test.yml
@@ -11,6 +11,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+# Least privilege for GITHUB_TOKEN. These jobs only check out the repo and run
+# node; nothing here talks to the GitHub API. Without this key the token is
+# whatever the repository default happens to be, which is a wider grant than
+# anything in this file uses.
+permissions:
+  contents: read
+
 jobs:
   checks:
     name: Lint, typecheck and test

--- a/.github/workflows/manual-eas-build.yml
+++ b/.github/workflows/manual-eas-build.yml
@@ -13,6 +13,12 @@ on:
           - android
           - ios
 
+# Least privilege for GITHUB_TOKEN. This workflow authenticates to EAS with
+# EXPO_TOKEN and never calls the GitHub API: expo-github-action is only given
+# an Expo token here, and the build runs on EAS rather than in this job.
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes the two open code scanning alerts, both `actions/missing-workflow-permissions` (medium).

Neither workflow declared a `permissions:` key, so `GITHUB_TOKEN` got whatever the repository default grants. That default is almost always wider than the workflow needs, and a compromised action anywhere in the dependency chain inherits the whole grant.

I checked what each actually uses rather than guessing:

**`format-test.yml`** — clones the repo, sets up node, installs, runs Biome, ESLint, `tsc` and Jest. No GitHub API calls.

**`manual-eas-build.yml`** — clones the repo, sets up node, authenticates to EAS with `EXPO_TOKEN`, installs, and runs `eas build`. The build runs *on EAS*, not in the job. `expo/expo-github-action@v8` is given an Expo token here and no GitHub token, so its PR-commenting path is not in use.

So `contents: read` is the whole requirement for both.

`manual-eas-build.yml` is a release path I cannot exercise from a PR — it is `workflow_dispatch` only. If a future change to it needs to write back to the repo or comment on a PR, that job will need its own wider `permissions:` block, and the workflow-level default here will make that an explicit decision rather than a silent inheritance.